### PR TITLE
Fix Docker environment and update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.4
+FROM ruby:3.2.2
 ENV LANG C.UTF-8
 ENV TZ Asia/Tokyo
 RUN apt-get update -qq \

--- a/README.md
+++ b/README.md
@@ -239,10 +239,18 @@ MVPリリース
 
 ## 使用する技術スタック
 ### 基本構成
-- **フレームワーク**: Ruby on Rails 7.0.x
+- **フレームワーク**: Ruby on Rails 7.0.10
+- **Ruby**: 3.2.2
 - **データベース**: PostgreSQL
 - **デプロイ先**: AWS
 - **フロントエンド**: Hotwire (Turbo + Stimulus)
+
+## デプロイ
+- URL: http://35.74.180.37
+- 環境: AWS EC2
+
+## 今後の改善ポイント
+- HTTPS 化（ACM を使用）
 
 ### 認証・ユーザー管理
 - **Sorcery**


### PR DESCRIPTION
## 変更内容
- Docker 環境での Ruby バージョン不一致を修正
- Dockerfile の Ruby バージョンを 3.2.2 に更新
- README に技術スタックとデプロイ URL を追記

## 確認事項
- [x] Docker 環境で Rails アプリケーションが正常に起動することを確認
- [x] バージョン不一致の警告が消えたことを確認
- [x] README に技術スタックとデプロイ URL を追記