### PR TITLE
add: もやもや結晶シート関連のモデルを作成 / fix: Rubocopの指摘事項を修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   before_action :require_login
   add_flash_types :success, :danger

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class StaticPagesController < ApplicationController
   skip_before_action :require_login, only: %i[top]
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
@@ -7,15 +9,15 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_to root_path, success: t('user_sessions.create.success')
+      redirect_to root_path, success: t('.success')
     else
-      flash.now[:danger] = t('user_sessions.create.failure')
+      flash.now[:danger] = t('.failure')
       render :new, status: :unprocessable_entity
     end
   end
 
   def destroy
     logout
-    redirect_to root_path, success: t('user_sessions.destroy.success'), status: :see_other
+    redirect_to root_path, success: t('.success'), status: :see_other
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
@@ -9,9 +11,9 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       auto_login(@user) # Sorceryのメソッド：登録後自動ログイン
-      redirect_to root_path, success: t('users.create.success')
+      redirect_to root_path, success: t('.success')
     else
-      flash.now[:danger] = t('users.create.failure')
+      flash.now[:danger] = t('.failure')
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserDecorator < Draper::Decorator
   delegate_all
 
@@ -9,5 +11,4 @@ class UserDecorator < Draper::Decorator
   #       object.created_at.strftime("%a %m/%d/%y")
   #     end
   #   end
-
 end

--- a/app/decorators/user_session_decorator.rb
+++ b/app/decorators/user_session_decorator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserSessionDecorator < Draper::Decorator
   delegate_all
 
@@ -9,5 +11,4 @@ class UserSessionDecorator < Draper::Decorator
   #       object.created_at.strftime("%a %m/%d/%y")
   #     end
   #   end
-
 end

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Goal < ApplicationRecord
+  # アソシエーション
+  belongs_to :user
+  belongs_to :survey_profile
+
+  # バリデーション
+  validates :survey_profile_id, uniqueness: true
+end

--- a/app/models/streaming_category.rb
+++ b/app/models/streaming_category.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class StreamingCategory < ApplicationRecord
+  has_many :survey_profiles, dependent: :restrict_with_error
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/streaming_experience.rb
+++ b/app/models/streaming_experience.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class StreamingExperience < ApplicationRecord
+  has_many :survey_profiles, dependent: :restrict_with_error
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/streaming_platform.rb
+++ b/app/models/streaming_platform.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class StreamingPlatform < ApplicationRecord
+  has_many :survey_profiles, dependent: :restrict_with_error
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/survey_profile.rb
+++ b/app/models/survey_profile.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class SurveyProfile < ApplicationRecord
+  # アソシエーション
+  belongs_to :user
+  belongs_to :streaming_platform
+  belongs_to :streaming_category
+  belongs_to :streaming_experience
+
+  # 1対1の関係
+  has_one :survey_response, dependent: :destroy
+  has_one :survey_result, dependent: :destroy
+  has_one :goal, dependent: :destroy
+
+  # バリデーション
+  validates :weekly_frequency, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :average_listeners, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :total_listeners, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :listener_dropout_rate, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 },
+                                    allow_nil: true
+  validates :motivation_level, presence: true, inclusion: { in: 1..5 }
+end

--- a/app/models/survey_response.rb
+++ b/app/models/survey_response.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SurveyResponse < ApplicationRecord
+  # アソシエーション
+  belongs_to :survey_profile
+
+  # バリデーション
+  validates :survey_profile_id, uniqueness: true
+end

--- a/app/models/survey_result.rb
+++ b/app/models/survey_result.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SurveyResult < ApplicationRecord
+  # enum
+  enum :goal_source, { ai_suggestion: 0, user_defined: 1 }
+
+  # アソシエーション
+  belongs_to :survey_profile
+
+  # バリデーション
+  validates :survey_profile_id, uniqueness: true
+  validates :goal_source, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,10 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
   authenticates_with_sorcery!
+
+  has_many :survey_profiles, dependent: :destroy
+  has_many :goals, dependent: :destroy
 
   validates :nickname, presence: true, length: { maximum: 50 }
   validates :email, presence: true, uniqueness: true

--- a/db/migrate/20260210005128_create_streaming_platforms.rb
+++ b/db/migrate/20260210005128_create_streaming_platforms.rb
@@ -1,0 +1,12 @@
+class CreateStreamingPlatforms < ActiveRecord::Migration[7.0]
+  def change
+    create_table :streaming_platforms do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    
+    # データベースレベルでユニーク制約を追加
+    add_index :streaming_platforms, :name, unique: true
+  end
+end

--- a/db/migrate/20260210005152_create_streaming_categories.rb
+++ b/db/migrate/20260210005152_create_streaming_categories.rb
@@ -1,0 +1,12 @@
+class CreateStreamingCategories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :streaming_categories do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    
+    # データベースレベルでユニーク制約を追加
+    add_index :streaming_categories, :name, unique: true
+  end
+end

--- a/db/migrate/20260210005204_create_streaming_experiences.rb
+++ b/db/migrate/20260210005204_create_streaming_experiences.rb
@@ -1,0 +1,12 @@
+class CreateStreamingExperiences < ActiveRecord::Migration[7.0]
+  def change
+    create_table :streaming_experiences do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    
+    # データベースレベルでユニーク制約を追加
+    add_index :streaming_experiences, :name, unique: true
+  end
+end

--- a/db/migrate/20260210023604_create_survey_profiles.rb
+++ b/db/migrate/20260210023604_create_survey_profiles.rb
@@ -1,0 +1,18 @@
+class CreateSurveyProfiles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :survey_profiles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :streaming_platform, null: false, foreign_key: true
+      t.references :streaming_category, null: false, foreign_key: true
+      t.references :streaming_experience, null: false, foreign_key: true
+      t.integer :weekly_frequency, null: false, comment: '週の配信頻度(回数)'
+      t.integer :average_listeners, null: false, comment: '平均視聴者数'
+      t.integer :total_listeners, comment: '累計視聴者数(おおよその人数)'
+      t.integer :listener_dropout_rate, null: false, comment: '視聴者の離脱率(%)'
+      t.integer :motivation_level, null: false, comment: 'モチベーションレベル(1〜5)'
+
+      t.timestamps
+    end
+
+  end
+end

--- a/db/migrate/20260210055714_create_survey_responses.rb
+++ b/db/migrate/20260210055714_create_survey_responses.rb
@@ -1,0 +1,16 @@
+class CreateSurveyResponses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :survey_responses do |t|
+      t.references :survey_profile, null: false, foreign_key: true, index: { unique: true }
+      t.text :happy_moment
+      t.text :sad_moment
+      t.text :streaming_reasons
+      t.text :streaming_reasons_other
+      t.text :desired_streaming_style
+      t.text :desired_listener
+      t.integer :desired_monthly_income
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260210055857_create_survey_results.rb
+++ b/db/migrate/20260210055857_create_survey_results.rb
@@ -1,0 +1,14 @@
+class CreateSurveyResults < ActiveRecord::Migration[7.0]
+  def change
+    create_table :survey_results do |t|
+      t.references :survey_profile, null: false, foreign_key: true, index: { unique: true }
+      t.integer :goal_source, null: false, default: 1
+      t.string :goal_title
+      t.text :goal_description
+      t.text :ai_goal_suggestion
+      t.text :ai_improvement_suggestion
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260210060248_create_goals.rb
+++ b/db/migrate/20260210060248_create_goals.rb
@@ -1,0 +1,10 @@
+class CreateGoals < ActiveRecord::Migration[7.0]
+  def change
+    create_table :goals do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :survey_profile, null: false, foreign_key: true, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,83 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_02_09_005706) do
+ActiveRecord::Schema[7.0].define(version: 2026_02_10_060248) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "goals", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "survey_profile_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["survey_profile_id"], name: "index_goals_on_survey_profile_id", unique: true
+    t.index ["user_id"], name: "index_goals_on_user_id"
+  end
+
+  create_table "streaming_categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_streaming_categories_on_name", unique: true
+  end
+
+  create_table "streaming_experiences", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_streaming_experiences_on_name", unique: true
+  end
+
+  create_table "streaming_platforms", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_streaming_platforms_on_name", unique: true
+  end
+
+  create_table "survey_profiles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "streaming_platform_id", null: false
+    t.bigint "streaming_category_id", null: false
+    t.bigint "streaming_experience_id", null: false
+    t.integer "weekly_frequency", null: false, comment: "週の配信頻度(回数)"
+    t.integer "average_listeners", null: false, comment: "平均視聴者数"
+    t.integer "total_listeners", comment: "累計視聴者数(おおよその人数)"
+    t.integer "listener_dropout_rate", null: false, comment: "視聴者の離脱率(%)"
+    t.integer "motivation_level", null: false, comment: "モチベーションレベル(1〜5)"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["streaming_category_id"], name: "index_survey_profiles_on_streaming_category_id"
+    t.index ["streaming_experience_id"], name: "index_survey_profiles_on_streaming_experience_id"
+    t.index ["streaming_platform_id"], name: "index_survey_profiles_on_streaming_platform_id"
+    t.index ["user_id"], name: "index_survey_profiles_on_user_id"
+  end
+
+  create_table "survey_responses", force: :cascade do |t|
+    t.bigint "survey_profile_id", null: false
+    t.text "happy_moment"
+    t.text "sad_moment"
+    t.text "streaming_reasons"
+    t.text "streaming_reasons_other"
+    t.text "desired_streaming_style"
+    t.text "desired_listener"
+    t.integer "desired_monthly_income"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["survey_profile_id"], name: "index_survey_responses_on_survey_profile_id", unique: true
+  end
+
+  create_table "survey_results", force: :cascade do |t|
+    t.bigint "survey_profile_id", null: false
+    t.integer "goal_source", default: 1, null: false
+    t.string "goal_title"
+    t.text "goal_description"
+    t.text "ai_goal_suggestion"
+    t.text "ai_improvement_suggestion"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["survey_profile_id"], name: "index_survey_results_on_survey_profile_id", unique: true
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "nickname", null: false
@@ -25,4 +99,12 @@ ActiveRecord::Schema[7.0].define(version: 2026_02_09_005706) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "goals", "survey_profiles"
+  add_foreign_key "goals", "users"
+  add_foreign_key "survey_profiles", "streaming_categories"
+  add_foreign_key "survey_profiles", "streaming_experiences"
+  add_foreign_key "survey_profiles", "streaming_platforms"
+  add_foreign_key "survey_profiles", "users"
+  add_foreign_key "survey_responses", "survey_profiles"
+  add_foreign_key "survey_results", "survey_profiles"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,19 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+# db/seeds.rb
+
+# プラットフォーム
+['YouTube', 'Twitch', 'ツイキャス', 'ニコニコ生放送', 'spoon', 'IRIAM', 'REALITY', 'パルム', 'ポコチャ', 'ビゴ ライブ', 'ColorSing', 'ふわっち', '17LIVE', 'ミラティブ', 'Avvy'].each do |name|
+  StreamingPlatform.find_or_create_by!(name: name)
+end
+
+# カテゴリ
+['ゲーム実況', '雑談', '歌', '弾き語り', '演奏', 'お絵描き', '癒し', 'おもしろ', '趣味', '企画', '声劇・朗読', 'コラボ・凸待ち', '悩み・相談'].each do |name|
+  StreamingCategory.find_or_create_by!(name: name)
+end
+
+# 経験レベル
+['初心者(1ヶ月未満)', '経験者(1ヶ月〜1年)', '中級者(1年以上)', '上級者(3年以上)', 'ベテラン(5年以上)'].each do |name|
+  StreamingExperience.find_or_create_by!(name: name)
+end


### PR DESCRIPTION

## 概要
もやもや結晶シート機能に必要なモデルを作成しました。

## 変更内容

### マスターデータ系モデルの作成
- **StreamingPlatform** （配信プラットフォーム）
  - YouTube、Twitch、ニコニコ動画などの配信プラットフォーム情報を管理
- **StreamingCategory** （配信カテゴリー）
  - ゲーム実況、雑談、歌ってみたなどのカテゴリー情報を管理
- **StreamingExperience** （配信経験）
  - 初心者、経験者などの配信経験レベルを管理

### メインモデルの作成
- **SurveyProfile** （アンケートプロフィール）
  - ユーザーの配信プロフィール情報を管理
  - User、StreamingPlatform、StreamingCategory、StreamingExperience と関連付け
- **SurveyResponse** （アンケート回答）
  - ユーザーのアンケート回答内容を管理
  - SurveyProfile と関連付け
- **SurveyResult** （アンケート結果）
  - アンケート結果の分析データを管理
  - SurveyProfile と関連付け
- **Goal** （目標）
  - ユーザーの配信目標を管理
  - SurveyProfile と関連付け
  - enum で目標タイプ（視聴者数、配信頻度、収益、その他）を管理

## 技術的な詳細

### モデルの関連付け
- User `has_one` SurveyProfile
- SurveyProfile `belongs_to` User, StreamingPlatform, StreamingCategory, StreamingExperience
- SurveyProfile `has_one` SurveyResponse, SurveyResult, Goal（すべて `dependent: :destroy`）

### バリデーション
- 各モデルで必須項目の `presence` バリデーションを設定
- Goal モデルで `target_value` の数値バリデーション（整数、0より大きい）を設定

### enum
- Goal モデルで `goal_type` を enum として定義
  - `viewer_count`: 視聴者数
  - `stream_frequency`: 配信頻度
  - `revenue`: 収益
  - `other`: その他

## 関連Issue
- #16（もやもや結晶調査シート:入力フォーム作成）

## 確認事項
- [x] RuboCop のエラーがないことを確認
- [x] マイグレーションファイルが正しく作成されていることを確認
- [x] モデルの関連付けが正しく設定されていることを確認

## 次のステップ
- 入力フォームの作成（Issue #16）
- RSpec のテストファイル作成