### PR TITLE
add: モデル関連のFactoryBotの設定を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,7 @@ group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
 end
+
+group :test do
+  gem 'shoulda-matchers', '~> 5.0'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,6 +326,8 @@ GEM
       logger
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
+    shoulda-matchers (5.3.0)
+      activesupport (>= 5.2.0)
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
@@ -394,6 +396,7 @@ DEPENDENCIES
   rubocop
   rubocop-checkstyle_formatter
   rubocop-rails
+  shoulda-matchers (~> 5.0)
   sorcery (= 0.16.3)
   sprockets-rails
   turbo-rails (= 1.1.1)

--- a/spec/factories/goals.rb
+++ b/spec/factories/goals.rb
@@ -1,10 +1,6 @@
 FactoryBot.define do
   factory :goal do
     association :user
-    
-    sequence(:title) { |n| "目標#{n}" }
-    description { '目標の説明' }
-    target_date { 1.year.from_now }
-    status { 'active' }
+    association :survey_profile
   end
 end

--- a/spec/factories/streaming_categories.rb
+++ b/spec/factories/streaming_categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :streaming_category do
+    sequence(:name) { |n| "カテゴリ#{n}" }
+  end
+end

--- a/spec/factories/streaming_experiences.rb
+++ b/spec/factories/streaming_experiences.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :streaming_experience do
+    sequence(:name) { |n| "経験レベル#{n}" }
+  end
+end

--- a/spec/factories/streaming_platforms.rb
+++ b/spec/factories/streaming_platforms.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :streaming_platform do
+    sequence(:name) { |n| "プラットフォーム#{n}" }
+  end
+end

--- a/spec/factories/survey_profiles.rb
+++ b/spec/factories/survey_profiles.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :survey_profile do
     association :user
-    association :goal
+    association :streaming_platform
+    association :streaming_category
+    association :streaming_experience
     
-    platform { 'YouTube' }
-    category { 'ゲーム実況' }
-    experience { '初心者' }
-    frequency { '週3回' }
-    listener_count { 100 }
-    streaming_reason { '楽しいから' }
-    desired_style { 'エンタメ系' }
-    target_income { 10000 }
+    weekly_frequency { 3 }
+    average_listeners { 100 }
+    total_listeners { 1000 }
+    listener_dropout_rate { 2 }
+    motivation_level { 3 }
+    
   end
 end

--- a/spec/models/goal_spec.rb
+++ b/spec/models/goal_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Goal, type: :model do
+  describe 'アソシエーション' do
+    it { should belong_to(:user) }
+    it { should belong_to(:survey_profile) }
+  end
+
+  describe 'バリデーション' do
+    it '有効なファクトリを持つこと' do
+      goal = build(:goal)
+      expect(goal).to be_valid
+    end
+
+    it 'ユーザーがいなければ無効' do
+      goal = build(:goal, user: nil)
+      expect(goal).to be_invalid
+      expect(goal.errors[:user]).to include("を入力してください")
+    end
+
+    it 'survey_profile がいなければ無効' do
+      goal = build(:goal, survey_profile: nil)
+      expect(goal).to be_invalid
+      expect(goal.errors[:survey_profile]).to include("を入力してください")
+    end
+
+    it 'survey_profile_id が重複していれば無効' do
+      # 同じ user を使う（循環参照を避けるため）
+      user = create(:user)
+      survey_profile = create(:survey_profile, user: user)
+      create(:goal, user: user, survey_profile: survey_profile)
+      
+      # 別の survey_profile を作成
+      another_survey_profile = create(:survey_profile, user: user)
+      goal = build(:goal, user: user, survey_profile: survey_profile)
+      
+      expect(goal).to be_invalid
+      expect(goal.errors[:survey_profile_id]).to include("はすでに存在します")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,3 +69,10 @@ RSpec.configure do |config|
   # FactoryBotの設定を追加
   config.include FactoryBot::Syntax::Methods
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
## 変更内容
- RSpec と関連 gem のインストール
- FactoryBot の設定
- shoulda-matchers の設定
- モデルテスト用の Factory ファイルを追加

## 確認事項
- [x] テストが全て成功している (15 examples, 0 failures)
- [x] RSpec の設定が完了している
- [x] FactoryBot が正常に動作している