### PR TITLE
AWS環境用の設定修正

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,6 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
-import "./controllers"
+// import "./controllers"  //
 import * as bootstrap from "bootstrap"
 
 // Bootstrap の Collapse を初期化する関数

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "esbuild": "^0.27.2"
   },
   "scripts": {
-    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets"
+    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets",
+    "build:css": "echo 'No CSS build required'"
   }
 }


### PR DESCRIPTION
## 概要
AWS環境でのデプロイに向けて、以下の設定を修正しました。

## 変更内容
- **`config/environments/production.rb`** の `force_ssl` を `false` に変更
  - ローカル環境での HTTPS 強制を無効化
- **`app/javascript/application.js`** の `import "./controllers"` をコメントアウト
  - Stimulus.js の読み込みを一時的に無効化
- **`package.json`** の `build:css` スクリプトを修正
  - CSS ビルドが不要な場合のエラーを回避

## 動作確認
- ローカル環境で Docker を再起動し、正常に動作することを確認
- ブラウザでページが正しく表示されることを確認
- JavaScript と CSS が正しく読み込まれることを確認

## 備考
- この変更は AWS 環境でのデプロイを準備するための一時的な修正です
- 本番環境では `force_ssl` を `true` に戻す必要があります