### PR TITLE
輝きの編集・削除・キャンセル機能実装

### DIFF
--- a/app/controllers/sparks_controller.rb
+++ b/app/controllers/sparks_controller.rb
@@ -1,22 +1,66 @@
+# frozen_string_literal: true
+
 class SparksController < ApplicationController
   before_action :require_login
   before_action :set_goal
+  before_action :set_spark, only: %i[edit update destroy]
 
-  def create
-  @spark = current_user.sparks.build(spark_params)
-  @spark.goal_id = params[:goal_id]
-  @goal = Goal.find(params[:goal_id])
+  def edit
+    @goal = current_user.goals.find(params[:goal_id])
+    @spark = @goal.sparks.find(params[:id])
 
-  respond_to do |format|
-    if @spark.save
-      flash.now[:success] = '✨ 輝きを記録しました！'
+    respond_to do |format|
       format.turbo_stream
-    else
-      flash.now[:danger] = '輝きの記録に失敗しました'
-      format.turbo_stream { render turbo_stream: turbo_stream.replace("spark_form", partial: "sparks/form", locals: { goal: @goal, spark: @spark }) }
+      format.html { redirect_to goal_path(@goal) } # HTML リクエストの場合はリダイレクト
     end
   end
-end
+
+  def create
+    @spark = current_user.sparks.build(spark_params)
+    @spark.goal_id = params[:goal_id]
+    @goal = Goal.find(params[:goal_id])
+
+    respond_to do |format|
+      if @spark.save
+        flash.now[:success] = '✨ 輝きを記録しました！'
+        format.turbo_stream
+      else
+        flash.now[:danger] = '輝きの記録に失敗しました'
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace('spark_form', partial: 'sparks/form',
+                                                                  locals: { goal: @goal, spark: @spark })
+        end
+      end
+    end
+  end
+
+  def update
+    @goal = current_user.goals.find(params[:goal_id])
+    @spark = @goal.sparks.find(params[:id])
+
+    @spark.update(spark_params)
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
+  def cancel
+    @goal = current_user.goals.find(params[:goal_id])
+    @spark = @goal.sparks.find(params[:id])
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
+  def destroy
+    @spark.destroy
+    respond_to do |format|
+      flash.now[:success] = '輝きを削除しました'
+      format.turbo_stream
+    end
+  end
 
   private
 
@@ -24,6 +68,12 @@ end
     @goal = current_user.goals.find(params[:goal_id])
   rescue ActiveRecord::RecordNotFound
     redirect_to goals_path, alert: '目標が見つかりませんでした'
+  end
+
+  def set_spark
+    @spark = @goal.sparks.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to goal_path(@goal), alert: '輝きが見つかりませんでした'
   end
 
   def spark_params

--- a/app/controllers/survey_profiles_controller.rb
+++ b/app/controllers/survey_profiles_controller.rb
@@ -55,7 +55,7 @@ class SurveyProfilesController < ApplicationController
     @streaming_reasons = params[:survey_profile][:streaming_reasons]&.reject(&:blank?) || []
 
     flash.now[:alert] = t('goals.update.failure')
-    render :edit
+    render :edit, status: :unprocessable_entity
   end
 
   private

--- a/app/decorators/spark_decorator.rb
+++ b/app/decorators/spark_decorator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SparkDecorator < Draper::Decorator
   delegate_all
 
@@ -9,5 +11,4 @@ class SparkDecorator < Draper::Decorator
   #       object.created_at.strftime("%a %m/%d/%y")
   #     end
   #   end
-
 end

--- a/app/models/spark.rb
+++ b/app/models/spark.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Spark < ApplicationRecord
   belongs_to :user
   belongs_to :goal

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -86,10 +86,8 @@
           </span>
         </div>
 
-        <!-- フラッシュメッセージ -->
-        <div id="flash-messages" class="mb-3">
-          <%= render 'shared/flash_messages' if flash.any? %>
-        </div>
+        <%# ⭐ 成功メッセージ表示用のコンテナ %>
+        <div id="spark-flash-messages" class="mb-3"></div>
 
         <!-- 投稿フォーム -->
         <div class="spark-form-wrapper mb-4" id="spark_form_wrapper">

--- a/app/views/sparks/_edit_form.html.erb
+++ b/app/views/sparks/_edit_form.html.erb
@@ -1,0 +1,59 @@
+<div id="<%= dom_id(spark) %>" class="mt-3 p-3 rounded" style="background-color: #f0f9ff; border: 2px solid #3b82f6;">
+  <%= form_with model: [goal, spark], 
+                class: "spark-edit-form" do |f| %>
+    
+    <!-- ⭐ エラーメッセージ（IDを追加して競合を防ぐ） -->
+    <% if spark.errors.any? %>
+      <div id="spark-error-messages-<%= spark.id %>" class="alert alert-danger alert-dismissible fade show mb-3" role="alert">
+        <strong>エラーが発生しました：</strong>
+        <ul class="mb-0 mt-2">
+          <% spark.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      </div>
+    <% end %>
+
+    <!-- テキストエリア -->
+    <%= f.text_area :content,
+                    class: "form-control shadow-sm",
+                    rows: 4,
+                    placeholder: "輝きを編集...",
+                    id: "spark_edit_content_#{spark.id}",
+                    style: "border: 2px solid #3b82f6; border-radius: 0.5rem;" %>
+
+    <!-- 文字数カウント -->
+    <div class="d-flex justify-content-between align-items-center mt-3">
+      <span class="text-muted small">
+        <span id="edit-char-count-<%= spark.id %>">
+          <%= spark.content.length %>
+        </span> / 500文字
+      </span>
+
+      <!-- ボタン -->
+      <div class="d-flex gap-2">
+        <%= link_to "キャンセル",
+                    cancel_goal_spark_path(goal, spark),
+                    data: { turbo_stream: true },
+                    class: "btn btn-sm btn-secondary" %>
+        <%= f.submit "更新する",
+                     class: "btn btn-primary fw-bold",
+                     data: { disable_with: "更新中..." } %>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<script>
+  (function() {
+    const textarea = document.getElementById('spark_edit_content_<%= spark.id %>');
+    const counter = document.getElementById('edit-char-count-<%= spark.id %>');
+    
+    if (textarea && counter) {
+      textarea.addEventListener('input', function() {
+        counter.textContent = this.value.length;
+      });
+    }
+  })();
+</script>

--- a/app/views/sparks/_spark.html.erb
+++ b/app/views/sparks/_spark.html.erb
@@ -1,30 +1,53 @@
-<div class="spark-item mb-3" id="<%= dom_id(spark) %>">
-  <div class="card shadow-sm">
-    <div class="card-body p-3 p-md-4">
-      <div class="d-flex align-items-start gap-3">
-        <!-- アバター -->
-        <div class="flex-shrink-0">
-          <div class="rounded-circle d-flex align-items-center justify-content-center" 
-               style="width: 48px; height: 48px; background: linear-gradient(to bottom right, #ec4899, #a855f7);">
-            <span class="text-white fw-bold" style="font-size: 1.25rem;">
-              <%= spark.user.nickname.first %>
-            </span>
-          </div>
-        </div>
-        
-        <!-- コンテンツ -->
-        <div class="flex-grow-1">
-          <div class="d-flex justify-content-between align-items-start mb-2">
-            <div>
-              <p class="fw-bold mb-0 text-dark"><%= spark.user.nickname %></p>
-              <small class="text-muted">
-                <%= l spark.created_at, format: :short %>
-              </small>
+<div id="<%= dom_id(spark) %>">
+  <div class="spark-item mb-3">
+    <div class="card shadow-sm">
+      <div class="card-body p-3 p-md-4">
+        <div class="d-flex align-items-start gap-3">
+          <!-- アバター -->
+          <div class="flex-shrink-0">
+            <div class="rounded-circle d-flex align-items-center justify-content-center" 
+                 style="width: 48px; height: 48px; background: linear-gradient(to bottom right, #ec4899, #a855f7);">
+              <span class="text-white fw-bold" style="font-size: 1.25rem;">
+                <%= spark.user.nickname.first %>
+              </span>
             </div>
           </div>
           
-          <div class="spark-content p-3 rounded" style="background-color: #f9fafb;">
-            <%= simple_format(h(spark.content), class: "mb-0 text-dark") %>
+          <!-- コンテンツ -->
+          <div class="flex-grow-1">
+            <div class="d-flex justify-content-between align-items-start mb-2">
+              <div>
+                <p class="fw-bold mb-0 text-dark"><%= spark.user.nickname %></p>
+                <small class="text-muted">
+                  投稿日時: <%= l spark.created_at, format: :short %>
+                  <% if spark.created_at != spark.updated_at %>
+                    （最終更新: <%= l spark.updated_at, format: :short %>）
+                  <% end %>
+                </small>
+              </div>
+              
+              <!-- 編集・削除ボタン（自分の投稿のみ表示） -->
+              <% if spark.user == current_user %>
+                <div class="d-flex gap-2">
+                  <%= link_to "編集",
+                                edit_goal_spark_path(spark.goal, spark),
+                                data: { turbo_stream: true },  # ← これを追加
+                                class: "btn btn-sm btn-outline-primary" %>
+                  <%= button_to "削除",
+                                goal_spark_path(spark.goal, spark),
+                                method: :delete,
+                                data: { 
+                                  turbo_confirm: "本当に削除しますか?",
+                                  turbo_frame: "_top"
+                                },
+                                class: "btn btn-sm btn-outline-danger" %>
+                </div>
+              <% end %>
+            </div>
+
+            <div class="spark-content p-3 rounded" style="background-color: #f9fafb;">
+              <%= simple_format(h(spark.content), class: "mb-0 text-dark") %>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/sparks/cancel.turbo_stream.erb
+++ b/app/views/sparks/cancel.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@spark) do %>
+   <%= render @spark, goal: @goal %>
+<% end %>

--- a/app/views/sparks/create.turbo_stream.erb
+++ b/app/views/sparks/create.turbo_stream.erb
@@ -1,19 +1,32 @@
-<!-- 1. 空のメッセージを削除（存在する場合） -->
-<%= turbo_stream.remove "sparks_empty_message" %>
-
-<!-- 2. 新しい輝きを一覧の先頭に追加 -->
-<%= turbo_stream.prepend "sparks_list" do %>
-  <%= render partial: 'sparks/spark', locals: { spark: @spark } %>
-<% end %>
-
-<!-- 3. フォームをリセット -->
-<%= turbo_stream.replace "spark_form" do %>
-  <%= turbo_frame_tag "spark_form" do %>
-    <%= render 'sparks/form', goal: @goal, spark: Spark.new %>
+<% if @spark.errors.any? %>
+  <%# ⭐ エラー時：フォームを再表示 %>
+  <%= turbo_stream.replace "spark_form" do %>
+    <%= turbo_frame_tag "spark_form" do %>
+      <%= render 'sparks/form', goal: @goal, spark: @spark %>
+    <% end %>
   <% end %>
-<% end %>
 
-<!-- 4. フラッシュメッセージを更新 -->
-<%= turbo_stream.update "flash-messages" do %>
-  <%= render 'shared/flash_message' %>
+<% else %>
+  <%# 1. 空のメッセージを削除（存在する場合） %>
+  <%= turbo_stream.remove "sparks_empty_message" %>
+
+  <%# 2. 新しい輝きを一覧の先頭に追加 %>
+  <%= turbo_stream.prepend "sparks_list" do %>
+    <%= render partial: 'sparks/spark', locals: { spark: @spark } %>
+  <% end %>
+
+  <%# 3. フォームをリセット %>
+  <%= turbo_stream.replace "spark_form" do %>
+    <%= turbo_frame_tag "spark_form" do %>
+      <%= render 'sparks/form', goal: @goal, spark: Spark.new %>
+    <% end %>
+  <% end %>
+
+  <%# 4. 成功メッセージを「✨ 輝きの記録」のタイトル下に表示 %>
+  <%= turbo_stream.update "spark-flash-messages" do %>
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+      ✨ 輝きを記録しました
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/sparks/destroy.turbo_stream.erb
+++ b/app/views/sparks/destroy.turbo_stream.erb
@@ -1,0 +1,18 @@
+<!-- 削除した投稿を、フラッシュメッセージで置き換える -->
+<%= turbo_stream.replace dom_id(@spark) do %>
+  <div class="alert alert-success alert-dismissible fade show mb-3" role="alert" id="delete_flash_<%= @spark.id %>">
+    <%= flash[:success] %>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  </div>
+  <script>
+    (function() {
+      const alert = document.getElementById('delete_flash_<%= @spark.id %>');
+      if (alert) {
+        setTimeout(() => {
+          alert.classList.remove('show');
+          setTimeout(() => alert.remove(), 150);
+        }, 3000);
+      }
+    })();
+  </script>
+<% end %>

--- a/app/views/sparks/edit.turbo_stream.erb
+++ b/app/views/sparks/edit.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@spark) do %>
+  <%= render "edit_form", spark: @spark, goal: @goal %>
+<% end %>

--- a/app/views/sparks/update.turbo_stream.erb
+++ b/app/views/sparks/update.turbo_stream.erb
@@ -1,0 +1,31 @@
+<% if @spark.errors.any? %>
+  <%# ⭐ エラー時：編集フォームを再表示 %>
+  <%= turbo_stream.replace dom_id(@spark) do %>
+     <%= render "sparks/edit_form", goal: @goal, spark: @spark %>
+  <% end %>
+
+<% else %>
+  <%# ⭐ 成功時：投稿を更新 %>
+  <%= turbo_stream.replace dom_id(@spark) do %>
+    <%= render @spark, goal: @goal %>
+  <% end %>
+
+  <%# ⭐ 成功メッセージを投稿の直前に表示 %>
+  <%= turbo_stream.before dom_id(@spark) do %>
+    <div class="alert alert-success alert-dismissible fade show mb-3" role="alert" id="flash-success-<%= @spark.id %>">
+      輝きを更新しました
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <script>
+      (function() {
+        const alert = document.getElementById('flash-success-<%= @spark.id %>');
+        if (alert) {
+          setTimeout(() => {
+            alert.classList.remove('show');
+            setTimeout(() => alert.remove(), 150);
+          }, 3000);
+        }
+      })();
+    </script>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,11 @@ Rails.application.routes.draw do
     resource :survey_profile, only: %i[edit update]  # ← ここを確認!
 
     # 輝き（Spark）の投稿機能
-    resources :sparks, only: [:create]  # ← この位置で正解！
+    resources :sparks, only: [:create, :edit, :update, :destroy] do
+      member do
+        get :cancel  # キャンセルアクション
+      end
+    end
 
     member do
       get :progress  # 進捗状況ページ（オプション）

--- a/spec/factories/sparks.rb
+++ b/spec/factories/sparks.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :spark do
+    content { '今日も頑張ろう！' }
+    association :goal
+    association :user # ⭐ user の関連付けを追加
+  end
+end

--- a/spec/models/spark_spec.rb
+++ b/spec/models/spark_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spark, type: :model do
+  describe 'バリデーション' do
+    let(:user) { create(:user) }
+    let(:goal) { create(:goal, user: user) }
+
+    it '有効なファクトリを持つこと' do
+      spark = build(:spark, goal: goal)
+      expect(spark).to be_valid
+    end
+
+    it '内容が必須であること' do
+      spark = build(:spark, goal: goal, content: nil)
+      expect(spark).not_to be_valid
+      expect(spark.errors[:content]).to include('を入力してください')
+    end
+
+    it '内容が500文字以内であること' do
+      spark = build(:spark, goal: goal, content: 'a' * 501)
+      expect(spark).not_to be_valid
+      expect(spark.errors[:content]).to include('は500文字以内で入力してください')
+    end
+
+    it '内容が500文字であれば有効であること' do
+      spark = build(:spark, goal: goal, content: 'a' * 500)
+      expect(spark).to be_valid
+    end
+  end
+
+  describe 'アソシエーション' do
+    it 'goalに属すること' do
+      association = described_class.reflect_on_association(:goal)
+      expect(association.macro).to eq :belongs_to
+    end
+  end
+
+  describe 'スコープ' do
+    let(:user) { create(:user) }
+    let(:goal) { create(:goal, user: user) }
+
+    it '新しい順に並ぶこと' do
+      spark1 = create(:spark, goal: goal, created_at: 1.day.ago)
+      spark2 = create(:spark, goal: goal, created_at: 2.days.ago)
+      spark3 = create(:spark, goal: goal, created_at: Time.current)
+
+      expect(goal.sparks.order(created_at: :desc)).to eq [spark3, spark1, spark2]
+    end
+  end
+end

--- a/spec/system/sparks_spec.rb
+++ b/spec/system/sparks_spec.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Sparks', type: :system do
+  let(:user) { create(:user) }
+
+  # ⭐ survey_profile を作成すると、自動的に survey_result も作成される
+  let!(:survey_profile) { create(:survey_profile, user: user) }
+
+  # ⭐ goal を作成（これが重要!）
+  let!(:goal) { create(:goal, user: user, survey_profile: survey_profile) }
+
+  before do
+    # ⭐ ログイン処理
+    visit login_path
+
+    # ⭐ ログインページが表示されるまで待機
+    expect(page).to have_content('ログイン'), 'ログインページが表示されません'
+
+    # ⭐ フォームのフィールド名を確認
+    fill_in 'email', with: user.email
+    fill_in 'password', with: 'password'
+
+    click_button 'ログイン'
+
+    # ⭐ ログイン成功を確認
+    expect(page).to have_content('ログインしました'), 'ログインに失敗しました'
+  end
+
+  describe '輝きの投稿' do
+    it '輝きを投稿できること' do
+      visit goal_path(goal)
+
+      # ⭐ ページが表示されるまで待機
+      expect(page).to have_css('textarea[name="spark[content]"]'), 'フォームが表示されません'
+
+      fill_in 'spark[content]', with: '今日も頑張ろう！'
+      click_button '輝きを記録'
+
+      # ⭐ 投稿内容が表示されるまで待機
+      expect(page).to have_content('今日も頑張ろう！'), '投稿内容が表示されません'
+      expect(page).to have_content('輝きを記録しました'), 'フラッシュメッセージが表示されません'
+    end
+
+    it '空の内容では投稿できないこと' do
+      visit goal_path(goal)
+
+      # ⭐ ページが表示されるまで待機
+      expect(page).to have_css('textarea[name="spark[content]"]'), 'フォームが表示されません'
+
+      fill_in 'spark[content]', with: ''
+      click_button '輝きを記録'
+
+      # ⭐ エラーメッセージが表示されるまで待機
+      expect(page).to have_content('を入力してください'), 'エラーメッセージが表示されません'
+    end
+
+    it '500文字を超える内容では投稿できないこと' do
+      visit goal_path(goal)
+
+      # ⭐ ページが表示されるまで待機
+      expect(page).to have_css('textarea[name="spark[content]"]'), 'フォームが表示されません'
+
+      fill_in 'spark[content]', with: 'a' * 501
+      click_button '輝きを記録'
+
+      # ⭐ エラーメッセージが表示されるまで待機
+      expect(page).to have_content('は500文字以内で入力してください'), 'エラーメッセージが表示されません'
+    end
+  end
+
+  describe '輝きの編集' do
+    let!(:spark) { create(:spark, goal: goal, user: user, content: '元の内容') }
+
+    it '輝きを編集できること' do
+      visit goal_path(goal)
+
+      # ⭐ 投稿内容が表示されるまで待機
+      expect(page).to have_content('元の内容'), '投稿内容が表示されません'
+
+      # ⭐ data-turbo-stream 属性を持つ編集リンクをクリック
+      find('a[data-turbo-stream="true"]', text: '編集').click
+
+      # ⭐ 編集フォームが表示されるまで待機
+      expect(page).to have_css('textarea[name="spark[content]"]'), '編集フォームが表示されません'
+
+      textarea = find("textarea#spark_edit_content_#{spark.id}")
+      textarea.native.clear
+      textarea.set('編集後の内容')
+
+      click_button '更新する'
+
+      # ⭐ 編集後の内容が表示されるまで待機
+      expect(page).to have_content('編集後の内容'), '編集後の内容が表示されません'
+      expect(page).to have_content('輝きを更新しました'), 'フラッシュメッセージが表示されません'
+      expect(page).not_to have_content('元の内容'), '元の内容が残っています'
+    end
+
+    it '編集をキャンセルできること' do
+      visit goal_path(goal)
+
+      # ⭐ 投稿内容が表示されるまで待機
+      expect(page).to have_content('元の内容'), '投稿内容が表示されません'
+
+      # ⭐ data-turbo-stream 属性を持つ編集リンクをクリック
+      find('a[data-turbo-stream="true"]', text: '編集').click
+
+      # ⭐ 編集フォームが表示されるまで待機
+      expect(page).to have_css('textarea[name="spark[content]"]'), '編集フォームが表示されません'
+
+      # ⭐ data-turbo-stream 属性を持つキャンセルリンクをクリック
+      find('a[data-turbo-stream="true"]', text: 'キャンセル').click
+
+      # ⭐ 元の内容が表示され、フォームが非表示になるまで待機
+      expect(page).to have_content('元の内容'), '元の内容が表示されません'
+      expect(page).not_to have_css('form.spark-edit-form'), '編集フォームが残っています'
+    end
+  end
+
+  describe '輝きの削除', js: true do
+    let!(:spark) { create(:spark, goal: goal, user: user, content: '削除する内容') }
+
+    it '輝きを削除できること' do
+      visit goal_path(goal)
+
+      # ⭐ 投稿内容が表示されるまで待機
+      expect(page).to have_content('削除する内容'), '投稿内容が表示されません'
+
+      # ⭐ data-turbo-confirm 属性を持つ削除ボタンを特定してクリック
+      accept_confirm('本当に削除しますか?') do
+        find('button[data-turbo-confirm="本当に削除しますか?"]', text: '削除').click
+      end
+
+      # ⭐ フラッシュメッセージが表示されるまで待機
+      expect(page).to have_content('輝きを削除しました'), 'フラッシュメッセージが表示されません'
+
+      # ⭐ 削除された内容が表示されないことを確認
+      expect(page).not_to have_content('削除する内容'), '削除された内容が残っています'
+    end
+
+    it 'データが削除されること' do
+      visit goal_path(goal)
+
+      # ⭐ 投稿内容が表示されるまで待機
+      expect(page).to have_content('削除する内容'), '投稿内容が表示されません'
+
+      # ⭐ 削除前のカウントを取得
+      initial_count = Spark.count
+
+      # ⭐ data-turbo-confirm 属性を持つ削除ボタンを特定してクリック
+      accept_confirm('本当に削除しますか?') do
+        find('button[data-turbo-confirm="本当に削除しますか?"]', text: '削除').click
+      end
+
+      # ⭐ フラッシュメッセージが表示されるまで待機(削除処理の完了を確認)
+      expect(page).to have_content('輝きを削除しました'), 'フラッシュメッセージが表示されません'
+
+      # ⭐ 「削除する内容」が画面から消えるまで待つ
+      expect(page).not_to have_content('削除する内容'), '削除された内容が残っています'
+
+      # ⭐ 削除後のカウントを確認
+      expect(Spark.count).to eq(initial_count - 1), 'データが削除されていません'
+    end
+
+    it '削除後、一覧に表示されないこと' do
+      visit goal_path(goal)
+
+      # ⭐ 投稿内容が表示されるまで待機
+      expect(page).to have_content('削除する内容'), '投稿内容が表示されません'
+
+      # ⭐ data-turbo-confirm 属性を持つ削除ボタンを特定してクリック
+      accept_confirm('本当に削除しますか?') do
+        find('button[data-turbo-confirm="本当に削除しますか?"]', text: '削除').click
+      end
+
+      # ⭐ フラッシュメッセージが表示されるまで待機
+      expect(page).to have_content('輝きを削除しました'), 'フラッシュメッセージが表示されません'
+
+      # ⭐ 削除後、「削除する内容」が表示されないことを確認
+      expect(page).not_to have_content('削除する内容'), '削除された内容が残っています'
+    end
+  end
+end


### PR DESCRIPTION
## 変更内容
- Turbo Streamsを使った輝きの編集フォームの表示
- 輝きの編集・削除・キャンセル機能を実装
- テストコードを追加し、全て通過を確認

## テスト結果
- `docker compose exec web bundle exec rspec`：37 examples, 0 failures
- `docker compose exec web bundle exec rubocop`：47 files inspected, no offenses detected

## 動作確認
- 輝きの編集・削除・キャンセルが正しく動作することを確認