### PR TITLE
Add aws-sdk-s3 and dotenv-rails gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,12 @@ gem 'carrierwave', '2.2.2'
 gem 'fog-aws' # 本番環境でS3を使用するため
 gem 'mini_magick' # 画像のリサイズ用
 
+# AWS S3連携（本番環境で使用）
+gem 'aws-sdk-s3', require: false
+
+# 環境変数管理（本番環境で .env ファイルを読み込むため）
+gem 'dotenv-rails', groups: [:development, :production]
+
 gem 'turbo-rails', '1.1.1'
 
 # ページネーション関連のGem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,25 @@ GEM
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1220.0)
+    aws-sdk-core (3.242.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.122.0)
+      aws-sdk-core (~> 3, >= 3.241.4)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.213.0)
+      aws-sdk-core (~> 3, >= 3.241.4)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.21)
     benchmark (0.5.0)
@@ -130,6 +149,10 @@ GEM
       reline (>= 0.3.8)
     debug_inspector (1.2.0)
     diff-lcs (1.6.2)
+    dotenv (3.2.0)
+    dotenv-rails (3.2.0)
+      dotenv (= 3.2.0)
+      railties (>= 6.1)
     draper (4.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -192,6 +215,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
+    jmespath (1.6.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.18.0)
@@ -434,6 +458,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-s3
   better_errors
   binding_of_caller
   bootsnap
@@ -443,6 +468,7 @@ DEPENDENCIES
   cssbundling-rails
   dartsass-rails (~> 0.4.0)
   debug
+  dotenv-rails
   draper (= 4.0.2)
   factory_bot_rails
   faker


### PR DESCRIPTION
## 変更内容
- `aws-sdk-s3` gemを追加（本番環境でのS3連携用）
- `dotenv-rails` gemを追加（環境変数管理用）

## 目的
本番環境でのファイルアップロード機能をS3で実装するための準備

## 確認項目
- [x] `bundle install` が正常に完了
- [x] Gemfileに正しく追加されている
- [x] サーバーが正常に起動する