### PR TITLE
feat: バリデーションエラーとフラッシュメッセージの翻訳化を実装

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -14,9 +14,9 @@ class ProfilesController < ApplicationController
   def update
     @user = current_user
     if @user.update(user_params)
-      redirect_to profile_path, success: 'プロフィールを更新しました'
+      redirect_to profile_path, success: t('.success')
     else
-      flash.now[:danger] = 'プロフィールの更新に失敗しました'
+      flash.now[:danger] = t('.failure')
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/sparks_controller.rb
+++ b/app/controllers/sparks_controller.rb
@@ -22,10 +22,10 @@ class SparksController < ApplicationController
 
     respond_to do |format|
       if @spark.save
-        flash.now[:success] = '✨ 輝きを記録しました！'
+        # flash.now[:success] = t('sparks.create.success')
         format.turbo_stream
       else
-        flash.now[:danger] = '輝きの記録に失敗しました'
+        # flash.now[:danger] = t('sparks.create.failure')
         format.turbo_stream do
           render turbo_stream: turbo_stream.replace('spark_form', partial: 'sparks/form',
                                                                   locals: { goal: @goal, spark: @spark })
@@ -57,7 +57,7 @@ class SparksController < ApplicationController
   def destroy
     @spark.destroy
     respond_to do |format|
-      flash.now[:success] = '輝きを削除しました'
+      flash.now[:success] = t('.success')
       format.turbo_stream
     end
   end
@@ -67,13 +67,17 @@ class SparksController < ApplicationController
   def set_goal
     @goal = current_user.goals.find(params[:goal_id])
   rescue ActiveRecord::RecordNotFound
-    redirect_to goals_path, alert: '目標が見つかりませんでした'
+    # 現在はTurbo Streamレスポンスのみを使用しているため、リダイレクトは実行されない
+    # 将来的にHTMLレスポンスに対応する場合は、以下のコメントを外してください
+    # redirect_to goals_path, alert: t('goals.not_found')
   end
 
   def set_spark
     @spark = @goal.sparks.find(params[:id])
   rescue ActiveRecord::RecordNotFound
-    redirect_to goal_path(@goal), alert: '輝きが見つかりませんでした'
+    # 現在はTurbo Streamレスポンスのみを使用しているため、リダイレクトは実行されない
+    # 将来的にHTMLレスポンスに対応する場合は、以下のコメントを外してください
+    # redirect_to goal_path(@goal), alert: t('sparks.not_found')
   end
 
   def spark_params

--- a/app/controllers/survey_profiles_controller.rb
+++ b/app/controllers/survey_profiles_controller.rb
@@ -17,6 +17,7 @@ class SurveyProfilesController < ApplicationController
     if save_all_records
       redirect_to goal_path(@goal), notice: t('.success')
     else
+      flash.now[:alert] = t('.failure')
       load_select_options
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,7 +6,7 @@ class UserSessionsController < ApplicationController
   def new; end
 
   def create
-    @user = login(params[:email], params[:password])
+    @user = login(params[:user_session][:email], params[:user_session][:password])
 
     if @user
       redirect_to root_path, success: t('.success')

--- a/app/views/goals/_goal_card.html.erb
+++ b/app/views/goals/_goal_card.html.erb
@@ -80,12 +80,12 @@
       <div class="d-flex gap-2">
         <%= link_to goal_path(goal), 
             class: "flex-fill btn btn-primary btn-sm d-flex align-items-center justify-content-center" do %>
-          <span class="me-1">✨</span> 詳細
+          <span class="me-1">✨</span> <%= t('.actions.detail') %>
         <% end %>
         
         <%= link_to edit_goal_path(goal), 
             class: "flex-fill btn btn-secondary btn-sm d-flex align-items-center justify-content-center" do %>
-          <span class="me-1">✏️</span> 編集
+          <span class="me-1">✏️</span> <%= t('.actions.edit') %>
         <% end %>
       </div>
     </div>
@@ -100,10 +100,10 @@
             method: :delete,
             form: {
               style: "display: inline;",
-              onsubmit: "return confirm('本当に削除しますか?\\nこの操作は取り消せません。');"
+              onsubmit: "return confirm('#{t('.actions.delete_confirm')}');"
             },
             class: "btn text-xs text-danger fw-bold text-decoration-none border-0 bg-transparent p-0" do %>
-           <span class="me-1">🗑️</span> 削除
+           <span class="me-1">🗑️</span> <%= t('.actions.delete') %>
         <% end %>
       </div>
     </div>

--- a/app/views/goals/edit.html.erb
+++ b/app/views/goals/edit.html.erb
@@ -1,19 +1,10 @@
 <div class="container mx-auto px-4 py-8">
-  <h1 class="text-3xl font-bold mt-5 mb-6 text-center">✨ 成長の星を編集 📝✨</h1>
-  <p class="text-center text-gray-600 mb-5">君のもやもやを見直してみよう🌟</p>
+  <h1 class="text-3xl font-bold mt-5 mb-6 text-center"><%= t('.title') %></h1>
+  <p class="text-center text-gray-600 mb-5"><%= t('.description') %></p>
 
   <%= form_with model: [@goal, @survey_profile], local: true do |f| %>
     <!-- エラーメッセージ表示 -->
-    <% if @survey_profile.errors.any? %>
-      <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-        <p class="font-bold"><%= pluralize(@survey_profile.errors.count, "error") %> prohibited this survey_profile from being saved:</p>
-        <ul class="list-disc list-inside">
-          <% @survey_profile.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
+    <%= render 'shared/error_messages', object: f.object %>
 
     <!-- ========================================
          基本情報セクション
@@ -282,7 +273,7 @@
 
     <!-- 送信ボタン -->
     <div class="text-center">
-      <%= f.submit '成長の星を更新する ✨', 
+      <%= f.submit t('.submit_button'), 
                class: 'text-white font-bold py-3 px-8 transition duration-300 text-lg cursor-pointer',
                style: 'background: linear-gradient(to right, #d9ec48, #5590f7); border-radius: 0.5rem; border: none;' %>
     </div>

--- a/app/views/goals/index.html.erb
+++ b/app/views/goals/index.html.erb
@@ -3,7 +3,7 @@
   <div class="mb-8">
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3">
       <h1 class="text-3xl md:text-4xl font-bold text-gray-800 mt-4">
-        <span class="text-4xl md:text-5xl">⭐</span> 成長の星 一覧
+        <%= t('.title') %>
       </h1>
     </div>
     
@@ -11,8 +11,7 @@
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mt-4 mb-4">
       <!-- 説明文 -->
       <p class="text-gray-600 mb-0">
-        あなたのもやもやから生まれた成長の星たちです。<br class="md:hidden">
-        それぞれの星を育てて、輝かせましょう!
+        <%= t('.description_html') %>
       </p>
 
       <!-- アクションボタンエリア -->
@@ -20,7 +19,7 @@
         <%= link_to new_survey_profile_path,
             class: "btn btn-lg text-white fw-bold shadow-lg",
             style: "background: linear-gradient(to right, #ec4899, #a855f7);" do %>
-          <span style="font-size: 1.25rem;">+もやもや結晶を調査🔍</span>
+          <span style="font-size: 1.25rem;"><%= t('.new_survey_button') %></span>
         <% end %>
       </div>
     </div>
@@ -55,13 +54,13 @@
     <div class="text-center py-16 bg-gradient-to-br from-pink-50 to-purple-50 rounded-xl shadow-lg p-4">
       <div class="text-6xl mb-4 animate-bounce">🌟</div>
       <h2 class="text-2xl font-bold text-gray-800 mb-4">
-        まだ成長の星⭐が見つかっていません
+        <%= t('.no_goals.title') %>
       </h2>
       <p class="text-gray-600 mb-2">
-        もやもや結晶シートから
+        <%= t('.no_goals.subtitle') %>
       </p>
       <p class="text-gray-600 mb-8">
-        あなたの成長の星⭐を見つけましょう！
+        <%= t('.no_goals.description') %>
       </p>
       
       <div class="mt-6 text-sm text-gray-500">

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -5,9 +5,9 @@
       <!-- ヘッダー部分 -->
       <div class="text-center mb-4">
         <h1 class="display-5 fw-bold mb-2" style="background: linear-gradient(to right, #fffb00ff, #a855f7); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">
-          ✨ あなたの成長の星 ✨
+          <%= t('.title') %>
         </h1>
-        <p class="text-muted">あなたのもやもやから生まれた、輝く目標です</p>
+        <p class="text-muted"><%= t('.description') %></p>
       </div>
 
       <!-- 目標カード -->
@@ -27,17 +27,17 @@
             <!-- 編集・削除ボタン -->
             <div class="d-flex gap-2">
               <%= link_to edit_goal_path(@goal), class: "btn btn-lg btn-outline-primary shadow fw-bold" do %>
-                <i class="bi bi-pencil"></i> 編集
+                <i class="bi bi-pencil"></i> <%= t('.actions.edit') %>
               <% end %>
 
               <%= button_to goal_path(@goal), 
                   method: :delete,
                   form: { 
                     style: "display: inline;",
-                    onsubmit: "return confirm('本当に削除しますか?\\nこの操作は取り消せません。');" 
+                    onsubmit: "return confirm('#{t('.actions.delete_confirm')}');" 
                   },
                   class: "btn btn-lg btn-outline-danger shadow fw-bold" do %>
-                <i class="bi bi-trash"></i> 削除
+                <i class="bi bi-trash"></i> <%= t('.actions.delete') %>
               <% end %>
             </div>
           </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -3,7 +3,7 @@
     <div class="col-md-6">
       <div class="card shadow-sm">
         <div class="card-body">
-          <h3 class="card-title text-center mb-4">プロフィール編集</h3>
+          <h3 class="card-title text-center mb-4"><%= t('profiles.edit.title') %></h3>
 
           <%= form_with model: @user, url: profile_path, local: true, html: { multipart: true } do |f| %>
             
@@ -11,7 +11,7 @@
             <div class="mb-4 text-center">
               <div class="mb-3">
                 <% if @user.avatar? %>
-                  <%= image_tag @user.avatar.url, alt: '現在のアバター', 
+                  <%= image_tag @user.avatar.url, alt: t('profiles.edit.current_avatar'), 
                       class: 'rounded-circle img-thumbnail', 
                       style: 'width: 150px; height: 150px; object-fit: cover;' %>
                 <% else %>
@@ -22,37 +22,37 @@
                 <% end %>
               </div>
 
-              <%= f.label :avatar, 'プロフィール画像を変更', class: 'form-label' %>
+              <%= f.label :avatar, t('profiles.edit.avatar_label'), class: 'form-label' %>
               <%= f.file_field :avatar, class: 'form-control', accept: 'image/*' %>
               <%= f.hidden_field :avatar_cache %>
               
               <% if @user.avatar? %>
                 <div class="form-check mt-2">
                   <%= f.check_box :remove_avatar, class: 'form-check-input' %>
-                  <%= f.label :remove_avatar, '画像を削除', class: 'form-check-label' %>
+                  <%= f.label :remove_avatar, t('profiles.edit.remove_avatar'), class: 'form-check-label' %>
                 </div>
               <% end %>
             </div>
 
             <!-- ニックネーム -->
             <div class="mb-3">
-              <%= f.label :nickname, 'ニックネーム', class: 'form-label' %>
+              <%= f.label :nickname, t('profiles.edit.nickname_label'), class: 'form-label' %>
               <%= f.text_field :nickname, 
                  class: 'form-control', 
                  style: 'width: 100%; max-width: 300px;',
-                 placeholder: 'ニックネームを入力' %>
+                 placeholder: t('profiles.edit.nickname_placeholder') %>
             </div>
 
             <!-- メールアドレス -->
             <div class="mb-4">
-              <%= f.label :email, 'メールアドレス', class: 'form-label' %>
-              <%= f.email_field :email, class: 'form-control', placeholder: 'メールアドレスを入力' %>
+              <%= f.label :email, t('profiles.edit.email_label'), class: 'form-label' %>
+              <%= f.email_field :email, class: 'form-control', placeholder: t('profiles.edit.email_placeholder') %>
             </div>
 
             <!-- ボタン -->
             <div class="d-grid gap-2">
-              <%= f.submit '更新', class: 'btn btn-primary btn-lg' %>
-              <%= link_to 'キャンセル', profile_path, class: 'btn btn-outline-secondary btn-lg' %>
+              <%= f.submit t('profiles.edit.submit'), class: 'btn btn-primary btn-lg' %>
+              <%= link_to t('profiles.edit.cancel'), profile_path, class: 'btn btn-outline-secondary btn-lg' %>
             </div>
           <% end %>
         </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -6,8 +6,9 @@
           <!-- プロフィール画像（丸型） -->
           <div class="mb-4">
             <% if @user.avatar? %>
-              <%= image_tag @user.avatar.url, alt: "#{@user.nickname}のアバター", 
-                  class: "rounded-circle img-thumbnail", 
+              <%= image_tag @user.avatar.url,
+                  alt: t('profiles.show.avatar_alt', nickname: @user.nickname),
+                  class: "rounded-circle img-thumbnail",
                   style: "width: 150px; height: 150px; object-fit: cover;" %>
             <% else %>
               <div class="rounded-circle bg-secondary d-flex align-items-center justify-content-center mx-auto" 
@@ -27,7 +28,7 @@
 
           <!-- 編集ボタン -->
           <%= link_to edit_profile_path, class: 'btn btn-primary btn-lg w-100' do %>
-            <i class="bi bi-pencil me-2"></i>編集
+            <i class="bi bi-pencil me-2"></i><%= t('profiles.show.edit_button') %>
           <% end %>
         </div>
       </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,6 +1,10 @@
 <% if object.errors.any? %>
-  <div class="alert alert-danger">
-    <ul>
+  <div class="bg-white border border-gray-300 px-4 py-3 rounded mb-4">
+    <h4 class="font-bold text-lg mb-2">
+      <%= t('errors.template.header', model: object.class.model_name.human, count: object.errors.count) %>
+    </h4>
+    <p class="mb-2 text-gray-700"><%= t('errors.template.body') %></p>
+    <ul class="list-disc list-inside text-gray-700">
       <% object.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/sparks/_edit_form.html.erb
+++ b/app/views/sparks/_edit_form.html.erb
@@ -5,7 +5,7 @@
     <!-- ⭐ エラーメッセージ（IDを追加して競合を防ぐ） -->
     <% if spark.errors.any? %>
       <div id="spark-error-messages-<%= spark.id %>" class="alert alert-danger alert-dismissible fade show mb-3" role="alert">
-        <strong>エラーが発生しました：</strong>
+        <strong><%= t('sparks.edit_form.error_title') %></strong>
         <ul class="mb-0 mt-2">
           <% spark.errors.full_messages.each do |message| %>
             <li><%= message %></li>
@@ -19,7 +19,7 @@
     <%= f.text_area :content,
                     class: "form-control shadow-sm",
                     rows: 4,
-                    placeholder: "輝きを編集...",
+                    placeholder: t('sparks.edit_form.placeholder'),
                     id: "spark_edit_content_#{spark.id}",
                     style: "border: 2px solid #3b82f6; border-radius: 0.5rem;" %>
 
@@ -33,11 +33,11 @@
 
       <!-- ボタン -->
       <div class="d-flex gap-2">
-        <%= link_to "キャンセル",
+        <%= link_to t('sparks.edit_form.cancel'),
                     cancel_goal_spark_path(goal, spark),
                     data: { turbo_stream: true },
                     class: "btn btn-sm btn-secondary" %>
-        <%= f.submit "更新する",
+        <%= f.submit t('sparks.edit_form.submit'),
                      class: "btn btn-primary fw-bold",
                      data: { disable_with: "更新中..." } %>
       </div>

--- a/app/views/sparks/_form.html.erb
+++ b/app/views/sparks/_form.html.erb
@@ -6,7 +6,7 @@
         
         <div class="form-group">
           <%= f.text_area :content, 
-              placeholder: "今日の配信での成長を記録しよう✨（最大500文字）",
+              placeholder:  t('.placeholder'),
               rows: 4,
               class: "form-control shadow-sm",
               id: "spark_content",
@@ -19,14 +19,11 @@
           <% end %>
         </div>
         
-        <div class="d-flex justify-content-between align-items-center mt-3">
-          <span class="text-muted small">
-            <span id="current-count">0</span> / 500文字
-          </span>
-          <%= f.submit "✨ 輝きを記録", 
+        <div class="d-flex justify-content-end align-items-center mt-3">
+          <%= f.submit t('.submit_button'), 
               class: "btn btn-lg fw-bold shadow",
               style: "background: linear-gradient(to right, #ec4899, #a855f7); color: white; border: none;",
-              data: { disable_with: "記録中..." } %>
+              data: { disable_with: t('.submitting') } %>
         </div>
       <% end %>
     </div>

--- a/app/views/sparks/_spark.html.erb
+++ b/app/views/sparks/_spark.html.erb
@@ -19,9 +19,9 @@
               <div>
                 <p class="fw-bold mb-0 text-dark"><%= spark.user.nickname %></p>
                 <small class="text-muted">
-                  投稿日時: <%= l spark.created_at, format: :short %>
+                  <%= t('sparks.show.posted_at') %>: <%= l spark.created_at, format: :short %>
                   <% if spark.created_at != spark.updated_at %>
-                    （最終更新: <%= l spark.updated_at, format: :short %>）
+                    （<%= t('sparks.show.last_updated') %>: <%= l spark.updated_at, format: :short %>）
                   <% end %>
                 </small>
               </div>
@@ -29,15 +29,15 @@
               <!-- 編集・削除ボタン（自分の投稿のみ表示） -->
               <% if spark.user == current_user %>
                 <div class="d-flex gap-2">
-                  <%= link_to "編集",
+                  <%= link_to t('sparks.show.edit'),
                                 edit_goal_spark_path(spark.goal, spark),
                                 data: { turbo_stream: true },
                                 class: "btn btn-sm btn-outline-primary" %>
-                  <%= button_to "削除",
+                  <%= button_to t('sparks.show.delete'),
                                 goal_spark_path(spark.goal, spark),
                                 method: :delete,
                                 data: { 
-                                  turbo_confirm: "本当に削除しますか?",
+                                  turbo_confirm:  t('defaults.delete_confirm'),
                                   turbo_frame: "_top"
                                 },
                                 class: "btn btn-sm btn-outline-danger" %>

--- a/app/views/sparks/create.turbo_stream.erb
+++ b/app/views/sparks/create.turbo_stream.erb
@@ -25,7 +25,7 @@
   <%# 4. 成功メッセージを「✨ 輝きの記録」のタイトル下に表示 %>
   <%= turbo_stream.update "spark-flash-messages" do %>
     <div class="alert alert-success alert-dismissible fade show" role="alert">
-      ✨ 輝きを記録しました
+      <%= t('sparks.create.success') %>
       <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
   <% end %>

--- a/app/views/sparks/update.turbo_stream.erb
+++ b/app/views/sparks/update.turbo_stream.erb
@@ -13,7 +13,7 @@
   <%# ⭐ 成功メッセージを投稿の直前に表示 %>
   <%= turbo_stream.before dom_id(@spark) do %>
     <div class="alert alert-success alert-dismissible fade show mb-3" role="alert" id="flash-success-<%= @spark.id %>">
-      輝きを更新しました
+      <%= t('sparks.update.success') %>
       <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
     <script>

--- a/app/views/static_pages/contact.html.erb
+++ b/app/views/static_pages/contact.html.erb
@@ -1,7 +1,7 @@
 <div class='container'>
   <div class='row'>
     <div class='col-12 text-center my-5'>
-      <h1 class='display-4 fw-bold'>お問い合わせ</h1>
+      <h1 class='display-4 fw-bold'><%= t('.title') %></h1>
       <p class='lead mt-4'>
         推しスタ⭐に関するご質問やご意見がございましたら、お気軽にお問い合わせください。<br>
         以下のメールアドレスまでご連絡いただけますと幸いです。

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,7 +1,7 @@
 <div class='container'>
   <div class='row'>
     <div class='col-12 text-center my-5'>
-      <h1 class='display-4 fw-bold'>プライバシーポリシー</h1>
+      <h1 class='display-4 fw-bold'><%= t('.title') %></h1>
       <p class='lead mt-4'>
         推しスタ⭐では、ユーザーの個人情報を適切に管理し、保護することをお約束します。<br>
         以下のプライバシーポリシーをご確認ください。

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,7 +1,7 @@
 <div class='container'>
   <div class='row'>
     <div class='col-12 text-center my-5'>
-      <h1 class='display-4 fw-bold'>利用規約</h1>
+      <h1 class='display-4 fw-bold'><%= t('.title') %></h1>
       <p class='lead mt-4'>
         推しスタ⭐をご利用いただく際の規約をご確認ください。<br>
         本サービスをご利用いただくことで、以下の規約に同意したものとみなされます。

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -3,8 +3,7 @@
     <div class='col-12 text-center my-5'>
       <h1 class='display-4 fw-bold'>TOP</h1>
       <p class='lead mt-4'>
-        配信でのもやもやな結晶(想い)を調べて、<br>
-        成長の星⭐(目標)に大変身 星を空に描いて、輝く大星座 君だけの銀河を創り上げよう✨
+        <%= t('.description_html') %>
       </p>
     </div>
   </div>

--- a/app/views/survey_profiles/edit.html.erb
+++ b/app/views/survey_profiles/edit.html.erb
@@ -1,19 +1,10 @@
 <div class="container mx-auto px-4 py-8">
-  <h1 class="text-3xl font-bold mb-6 text-center">もやもや結晶シートを編集 📝</h1>
-  <p class="mb-8 text-center text-gray-600">君のもやもやを見直してみよう。新しい星が生まれるかも! 🌟</p>
+  <h1 class="text-3xl font-bold mb-6 text-center"><%= t('.title') %></h1>
+  <p class="mb-8 text-center text-gray-600"><%= t('.description') %></p>
 
   <%= form_with model: @survey_profile, url: goal_survey_profile_path(@goal), method: :patch, local: true do |f| %>
     <!-- エラーメッセージ表示 -->
-    <% if @survey_profile.errors.any? %>
-      <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-        <p class="font-bold"><%= pluralize(@survey_profile.errors.count, "error") %> prohibited this survey_profile from being saved:</p>
-        <ul class="list-disc list-inside">
-          <% @survey_profile.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
+    <%= render 'shared/error_messages', object: f.object %>
 
     <!-- ========================================
          基本情報セクション
@@ -281,8 +272,9 @@
 
     <!-- 送信ボタン -->
     <div class="text-center">
-      <%= f.submit '成長の星を更新する ✨', 
-                   class: 'bg-gradient-to-r from-pink-500 to-purple-500 text-white font-bold py-3 px-8 rounded-lg hover:from-pink-600 hover:to-purple-600 transition duration-300 text-lg cursor-pointer' %>
+      <%= f.submit t('.submit_button'), 
+               class: 'text-white font-bold py-3 px-8 transition duration-300 text-lg cursor-pointer',
+               style: 'background: linear-gradient(to right, #d9ec48, #5590f7); border-radius: 0.5rem; border: none;' %>
     </div>
   <% end %>
 </div>

--- a/app/views/survey_profiles/new.html.erb
+++ b/app/views/survey_profiles/new.html.erb
@@ -1,19 +1,10 @@
 <div class="container mx-auto px-4 py-8">
-  <h1 class="text-3xl font-bold mb-6 mt-5 text-center">もやもや結晶シート ✨</h1>
-  <p class="text-center text-gray-600 mb-5">君のもやもやを教えてね。きっと素敵な星が生まれるよ! 🌟</p>
+  <h1 class="text-3xl font-bold mb-6 mt-5 text-center"><%= t('.title') %></h1>
+  <p class="text-center text-gray-600 mb-5"><%= t('.description') %></p>
 
   <%= form_with model: @survey_profile, url: survey_profiles_path, local: true do |f| %>
     <!-- エラーメッセージ表示 -->
-    <% if @survey_profile.errors.any? %>
-      <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-        <p class="font-bold"><%= pluralize(@survey_profile.errors.count, "error") %> prohibited this survey_profile from being saved:</p>
-        <ul class="list-disc list-inside">
-          <% @survey_profile.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
+    <%= render 'shared/error_messages', object: f.object %>
 
     <!-- ========================================
          基本情報セクション
@@ -282,7 +273,7 @@
 
     <!-- 送信ボタン -->
     <div class="text-center">
-       <%= f.submit '成長の星を誕生させる ✨', 
+       <%= f.submit t('.submit_button'),
                class: 'text-white font-bold py-3 px-8 transition duration-300 text-lg cursor-pointer',
                style: 'background: linear-gradient(to right, #d9ec48, #5590f7); border-radius: 0.5rem; border: none;' %>
     </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,8 +1,8 @@
 <div class="container">
   <div class="row">
     <div class=" col-md-10 col-lg-8 mt-3 mx-auto">
-      <h1>ログイン</h1>
-      <%= form_with url: login_path do |f| %>
+      <h1><%= t('.title') %></h1>
+      <%= form_with url: login_path, scope: :user_session do |f| %>
         <div class="mb-3">
           <%= f.label :email %>
           <%= f.email_field :email, class: "form-control" %>
@@ -11,11 +11,11 @@
           <%= f.label :password %>
           <%= f.password_field :password, class: "form-control" %>
         </div>
-        <%= f.submit "ログイン", class: "btn btn-primary" %>
+        <%= f.submit t('.login'), class: "btn btn-primary" %>
       <% end %>
       <div class='text-center mt-5'>
-        <%= link_to '登録ページへ', new_user_path %>
-        <%= link_to 'パスワードをお忘れの方はこちら', '#' %>
+        <%= link_to t('.to_register_page'), new_user_path %>
+        <%= link_to t('.password_forget'), '#' %>
       </div>
     </div>
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,36 +1,36 @@
 <div class="container">
   <div class="row">
     <div class="col-md-10 col-lg-8 mt-3 mx-auto">
-      <h1>ユーザー登録</h1>
+      <h1><%= t('.title') %></h1>
 
       <%= form_with model: @user, local: true do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
 
         <div class="form-group mb-3">
-          <%= f.label :nickname, 'ニックネーム' %>
+          <%= f.label :nickname %>
           <%= f.text_field :nickname, class: 'form-control' %>
         </div>
 
         <div class="form-group mb-3">
-          <%= f.label :email, 'メールアドレス' %>
+          <%= f.label :email %>
           <%= f.email_field :email, class: 'form-control' %>
         </div>
 
         <div class="form-group mb-3">
-          <%= f.label :password, 'パスワード' %>
+          <%= f.label :password %>
           <%= f.password_field :password, class: 'form-control' %>
         </div>
 
         <div class="form-group mb-3">
-          <%= f.label :password_confirmation, 'パスワード確認' %>
+          <%= f.label :password_confirmation %>
           <%= f.password_field :password_confirmation, class: 'form-control' %>
         </div>
 
-        <%= f.submit '登録', class: 'btn btn-primary' %>
+        <%= f.submit class: 'btn btn-primary' %>
       <% end %>
       
       <div class='text-center mt-5'>
-        <%= link_to 'ログインページへ', login_path %>
+        <%= link_to t('.to_login_page'), login_path %>
       </div>
     </div>
   </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,59 @@
+ja:
+  helpers:
+    submit:
+      create: "登録"
+      update: "更新"
+    label:
+      user_session:
+        email: "メールアドレス"
+        password: "パスワード"
+
+  activerecord:
+    models:
+      goal: "成長の星"
+      spark: "きっかけ"
+      user: "ユーザー"
+      profile: "プロフィール"
+      survey_profile: "もやもや結晶シート調査"
+    
+    attributes:
+      goal:
+        title: "タイトル"
+        description: "説明"
+        deadline: "期限"
+        motivation: "モチベーション"
+        user: "ユーザー"
+      
+      spark:
+        title: "タイトル"
+        content: "内容"
+        spark_type: "種類"
+        goal: "成長の星"
+      
+      user:
+        nickname: "ニックネーム"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認）"
+      
+      profile:
+        nickname: "ニックネーム"
+        bio: "自己紹介"
+        avatar: "アバター"
+      
+      survey_profile:
+        streaming_platform: "配信プラットフォーム"
+        streaming_category: "配信カテゴリー"
+        streaming_experience: "配信経験"
+        weekly_frequency: "週あたりの配信回数"
+        average_listeners: "平均視聴者数"
+        total_listeners: "総合視聴者数"
+        motivation_level: "モチベーションレベル"
+        listener_dropout_rate: "最近のリスナー離脱人数"
+
+  errors:
+    template:
+      body: "次の項目を確認してください"
+      header:
+        one: "%{model}に1個のエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,10 +3,22 @@ ja:
     login: 'ログイン'
     logout: 'ログアウト'
     register: '新規登録'
+    delete_confirm: '本当に削除しますか?'
     message:
       require_login: 'ログインしてください'
 
+  static_pages:
+    top:
+      description_html: |
+        配信でのもやもやな結晶(想い)を調べて、<br>
+        成長の星⭐(目標)に大変身 星を空に描いて、輝く大星座 君だけの銀河を創り上げよう✨
+
   user_sessions:
+    new:
+      title: 'ログイン'
+      login: 'ログイン'
+      to_register_page: '登録ページへ'
+      password_forget: 'パスワードをお忘れの方はこちら'
     create:
       success: 'ログインしました'
       failure: 'メールアドレスまたはパスワードが正しくありません'
@@ -14,16 +26,51 @@ ja:
       success: 'ログアウトしました'
 
   users:
+    new:
+      title: "ユーザー登録"
+      to_login_page: "ログインページへ"
     create:
       success: 'ユーザー登録が完了しました'
       failure: 'ユーザー登録に失敗しました'
 
   goals:
+    index:
+      title: '⭐ 成長の星 一覧'
+      new_survey_button: '+もやもや結晶を調査🔍'
+      description_html: |
+        あなたのもやもやから生まれた成長の星たちです。<br class="md:hidden">
+        それぞれの星を育てて、輝かせましょう!
+      no_goals:
+        title: 'まだ成長の星⭐が見つかっていません'
+        subtitle: 'もやもや結晶シートから'
+        description: 'あなたの成長の星⭐を見つけましょう！'
+
+    not_found: '目標が見つかりませんでした'
+
+    goal_card:
+      actions:
+        detail: '詳細'
+        edit: '編集'
+        delete: '削除'
+        delete_confirm: '本当に削除しますか?\nこの操作は取り消せません。'
+
     show:
+      title: '✨ あなたの成長の星 ✨'
+      description: 'あなたのもやもやから生まれた、輝く目標です'
       access_denied: 'アクセス権限がありません'
       not_found: '成長の星⭐が見つかりませんでした'
+
+      actions:
+        edit: '編集'
+        delete: '削除'
+        delete_confirm: '本当に削除しますか?\nこの操作は取り消せません。'
+
     edit:
       title: '成長の星を編集'
+      submit_button: '成長の星を更新する ✨'
+      title: '✨ 成長の星を編集 ✨'
+      description: '君のもやもや結晶を見直してみよう。今以上に輝く星になれるよ🌟'
+
     update:
       success: '成長の星を更新しました'
       failure: '成長の星の更新に失敗しました'
@@ -32,6 +79,70 @@ ja:
       failure: '成長の星の削除に失敗しました'
 
   survey_profiles:
+    new:
+      title: 'もやもや結晶シート ✨'
+      description: '君のもやもやを教えてね。きっと素敵な星が生まれるよ! 🌟'
+      submit_button: '成長の星を誕生させる ✨'
     create:
       success: '成長の星が誕生しました! ✨🌟'
       failure: '成長の星の作成に失敗しました。もう一度お試しください。'
+    edit:
+      submit_button: '成長の星を更新する ✨'
+      title: '✨ 成長の星を編集 ✨'
+      description: '君のもやもや結晶を見直してみよう。今以上に輝く星になれるよ🌟'
+
+  sparks:
+    form:
+      submit_button: '✨ 輝きを記録'
+      submitting: '記録中...'
+      placeholder: '今日の配信での成長を記録しよう✨（最大500文字）'
+    edit_form:
+      placeholder: '輝きを編集...'
+      cancel: 'キャンセル'
+      submit: '更新する'
+      submitting: '更新中...'
+      error_title: 'エラーが発生しました：'
+    show:
+      edit: 編集
+      delete: 削除
+      posted_at: 投稿日時
+      last_updated: 最終更新
+
+    not_found: '輝きが見つかりませんでした'
+
+    create:
+      success: '✨ 輝きを記録しました！'
+      failure: '輝きの記録に失敗しました'
+    update:
+      success: '✨ 輝きを更新しました！'
+      failure: '輝きの更新に失敗しました'
+    destroy:
+      success: '輝きを削除しました'
+      failure: '輝きの削除に失敗しました'
+
+  profiles:
+    show:
+      avatar_alt: '%{nickname}のアバター'
+      edit_button: '編集'
+    edit:
+      title: 'プロフィール編集'
+      current_avatar: '現在のアバター'
+      avatar_label: 'プロフィール画像を変更'
+      remove_avatar: '画像を削除'
+      nickname_label: 'ニックネーム'
+      nickname_placeholder: 'ニックネームを入力'
+      email_label: 'メールアドレス'
+      email_placeholder: 'メールアドレスを入力'
+      submit: '更新'
+      cancel: 'キャンセル'
+    update:
+      success: 'プロフィールを更新しました'
+      failure: 'プロフィールの更新に失敗しました'
+
+  static_pages:
+    contact:
+      title: 'お問い合わせ'
+    privacy:
+      title: 'プライバシーポリシー'
+    terms:
+      title: '利用規約'

--- a/spec/system/goals_spec.rb
+++ b/spec/system/goals_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe 'Goals', type: :system do
     expect(page).to have_content('ログイン'), 'ログインページが表示されません'
 
     # ⭐ フォームのフィールド名を確認
-    fill_in 'email', with: user.email
-    fill_in 'password', with: 'password'
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: 'password'
 
     # ⭐ デバッグ: スクリーンショットを撮影
     # page.save_screenshot('tmp/capybara/before_click_login.png')
@@ -44,8 +44,8 @@ RSpec.describe 'Goals', type: :system do
 
         # ⭐ ログイン処理（手動）
         visit login_path
-        fill_in 'Email', with: user.email
-        fill_in 'Password', with: 'password' # FactoryBot で設定したパスワード
+        fill_in 'メールアドレス', with: user.email
+        fill_in 'パスワード', with: 'password' # FactoryBot で設定したパスワード
         click_button 'ログイン'
 
         # ⭐ goals_path にアクセス
@@ -112,7 +112,7 @@ RSpec.describe 'Goals', type: :system do
 
       click_button '成長の星を更新'
 
-      expect(page).to have_content('Weekly frequencyを入力してください')
+      expect(page).to have_content('週あたりの配信回数を入力してください')
     end
   end
 

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe 'Profiles', type: :system do
     expect(page).to have_content('ログイン'), 'ログインページが表示されません'
 
     # ⭐ フォームのフィールド名を確認
-    fill_in 'email', with: user.email
-    fill_in 'password', with: 'password'
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: 'password'
 
     click_button 'ログイン'
 

--- a/spec/system/sparks_spec.rb
+++ b/spec/system/sparks_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe 'Sparks', type: :system do
     expect(page).to have_content('ログイン'), 'ログインページが表示されません'
 
     # ⭐ フォームのフィールド名を確認
-    fill_in 'email', with: user.email
-    fill_in 'password', with: 'password'
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: 'password'
 
     click_button 'ログイン'
 


### PR DESCRIPTION
## 変更内容
- バリデーションエラーメッセージの翻訳化
- フラッシュメッセージの翻訳化
- 各ページのMVPで必須の翻訳化

## 確認項目
- [x] `docker compose exec web bundle exec rspec` が通る
- [x] `docker compose exec web bundle exec rubocop` が通る
- [x] ブラウザで動作確認済み
