### PR TITLE
MVPレビュー前の細かい修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,7 +36,7 @@ Rails/I18nLocaleTexts:
 
 # ⭐ メソッドの長さを緩和
 Metrics/MethodLength:
-  Max: 20
+  Max: 30
 
 # ⭐ クラスの長さを緩和
 Metrics/ClassLength:
@@ -44,7 +44,7 @@ Metrics/ClassLength:
 
 # ⭐ ABC サイズを緩和
 Metrics/AbcSize:
-  Max: 31
+  Max: 45
 
 # ⭐ Safe Navigation の長さを緩和
 Style/SafeNavigationChainLength:

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -52,3 +52,12 @@
     }
   }
 }
+
+// フォーム要素を縦並びでフォームの長さを整えるためのカスタムクラス
+.form-field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+  width: 100%;
+  max-width: 640px;
+}

--- a/app/controllers/sparks_controller.rb
+++ b/app/controllers/sparks_controller.rb
@@ -67,17 +67,13 @@ class SparksController < ApplicationController
   def set_goal
     @goal = current_user.goals.find(params[:goal_id])
   rescue ActiveRecord::RecordNotFound
-    # 現在はTurbo Streamレスポンスのみを使用しているため、リダイレクトは実行されない
-    # 将来的にHTMLレスポンスに対応する場合は、以下のコメントを外してください
-    # redirect_to goals_path, alert: t('goals.not_found')
+    Rails.logger.warn("Goal not found: #{params[:goal_id]} for user: #{current_user.id}")
   end
 
   def set_spark
     @spark = @goal.sparks.find(params[:id])
   rescue ActiveRecord::RecordNotFound
-    # 現在はTurbo Streamレスポンスのみを使用しているため、リダイレクトは実行されない
-    # 将来的にHTMLレスポンスに対応する場合は、以下のコメントを外してください
-    # redirect_to goal_path(@goal), alert: t('sparks.not_found')
+    Rails.logger.warn("Spark not found: #{params[:id]} for goal: #{@goal&.id}")
   end
 
   def spark_params

--- a/app/controllers/survey_profiles_controller.rb
+++ b/app/controllers/survey_profiles_controller.rb
@@ -18,7 +18,8 @@ class SurveyProfilesController < ApplicationController
       redirect_to goal_path(@goal), notice: t('.success')
     else
       flash.now[:alert] = t('.failure')
-      load_select_options
+      prepare_for_render
+
       render :new, status: :unprocessable_entity
     end
   end
@@ -33,27 +34,42 @@ class SurveyProfilesController < ApplicationController
     # survey_result が存在しない場合は build する
     survey_result = @survey_profile.survey_result || @survey_profile.build_survey_result
 
+    # パラメータを assign する
+    @survey_profile.assign_attributes(survey_profile_params)
+    survey_response.assign_attributes(survey_response_params)
+    survey_result.assign_attributes(survey_result_params)
+
+    # 各モデルのバリデーションを先にチェック
+    valid_profile = @survey_profile.valid?
+    valid_response = survey_response.valid?
+    valid_result = survey_result.valid?
+
+    # いずれかのバリデーションが失敗した場合
+    unless valid_profile && valid_response && valid_result
+      # エラーメッセージを集約
+      aggregate_errors(survey_response, survey_result)
+
+      # ビューの表示に必要な変数を設定
+      prepare_for_render
+
+      flash.now[:alert] = t('goals.update.failure')
+      render :edit, status: :unprocessable_entity
+      return
+    end
+
     # トランザクションで一括更新
     ActiveRecord::Base.transaction do
-      # survey_profile を更新
-      @survey_profile.update!(survey_profile_params)
-
-      # survey_response を更新
-      survey_response.update!(survey_response_params)
-
-      # survey_result を更新
-      survey_result.update!(survey_result_params)
+      @survey_profile.save!
+      survey_response.save!
+      survey_result.save!
 
       redirect_to @goal, notice: t('goals.update.success')
     end
-  rescue ActiveRecord::RecordInvalid
-    # バリデーションエラー時
-    @streaming_platforms = StreamingPlatform.all
-    @streaming_categories = StreamingCategory.all
-    @streaming_experiences = StreamingExperience.all
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.debug { "RecordInvalid: #{e.message}" }
 
-    # エラー時に @streaming_reasons を設定（チェックボックスの状態を復元）
-    @streaming_reasons = params[:survey_profile][:streaming_reasons]&.reject(&:blank?) || []
+    # ビューの表示に必要な変数を設定
+    prepare_for_render
 
     flash.now[:alert] = t('goals.update.failure')
     render :edit, status: :unprocessable_entity
@@ -72,12 +88,26 @@ class SurveyProfilesController < ApplicationController
 
   def save_all_records
     ActiveRecord::Base.transaction do
+      # 各モデルのバリデーションを先にチェック
+      valid_profile = @survey_profile.valid?
+      valid_response = @survey_profile.survey_response.valid?
+      valid_result = @survey_profile.survey_result.valid?
+
+      # いずれかのバリデーションが失敗した場合
+      unless valid_profile && valid_response && valid_result
+        # エラーメッセージを集約
+        aggregate_errors(@survey_profile.survey_response, @survey_profile.survey_result)
+
+        raise ActiveRecord::Rollback
+      end
+
       @survey_profile.save!
       @survey_profile.survey_response.save!
       @survey_profile.survey_result.save!
       @goal = create_goal
       @goal.persisted?
-    rescue ActiveRecord::RecordInvalid
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.debug { "RecordInvalid: #{e.message}" }
       false
     end
   end
@@ -102,6 +132,25 @@ class SurveyProfilesController < ApplicationController
     @streaming_platforms = StreamingPlatform.all
     @streaming_categories = StreamingCategory.all
     @streaming_experiences = StreamingExperience.all
+  end
+
+  # エラーメッセージを @survey_profile.errors に集約するメソッド
+  def aggregate_errors(survey_response, survey_result)
+    # survey_response のエラーメッセージを追加
+    survey_response.errors.each do |error|
+      @survey_profile.errors.add(:base, error.full_message)
+    end
+
+    # survey_result のエラーメッセージを追加
+    survey_result.errors.each do |error|
+      @survey_profile.errors.add(:base, error.full_message)
+    end
+  end
+
+  # ビューの表示に必要な変数を設定するメソッド
+  def prepare_for_render
+    load_select_options
+    @streaming_reasons = params[:survey_profile][:streaming_reasons]&.reject(&:blank?) || []
   end
 
   def survey_profile_params

--- a/app/models/survey_response.rb
+++ b/app/models/survey_response.rb
@@ -6,4 +6,17 @@ class SurveyResponse < ApplicationRecord
 
   # バリデーション
   validates :survey_profile_id, uniqueness: true
+  validate :streaming_reasons_count
+
+  private
+
+  def streaming_reasons_count
+    return if streaming_reasons.blank?
+
+    reasons_array = streaming_reasons.split(',').map(&:strip).compact_blank
+
+    return unless reasons_array.length > 3
+
+    errors.add(:streaming_reasons, 'は3つまで選択してください')
+  end
 end

--- a/app/views/goals/edit.html.erb
+++ b/app/views/goals/edit.html.erb
@@ -119,7 +119,7 @@
       </div>
 
       <!-- 配信で嬉しかった瞬間 -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[happy_moment]', '配信をしていて嬉しかったこと', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[happy_moment]',
                           @survey_profile.survey_response&.happy_moment,
@@ -129,7 +129,7 @@
       </div>
 
       <!-- 配信で辛かった瞬間 -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[sad_moment]', '配信をしていて悲しかったこと（もやもやの原因）', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[sad_moment]',
                           @survey_profile.survey_response&.sad_moment,
@@ -174,7 +174,7 @@
       </div>
 
       <!-- 配信を続ける理由（その他） -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[streaming_reasons_other]', '配信を続ける理由や目的（その他）', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[streaming_reasons_other]',
                           @survey_profile.survey_response&.streaming_reasons_other,
@@ -184,7 +184,7 @@
       </div>
 
       <!-- 理想の配信スタイル -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[desired_streaming_style]', '理想の配信スタイル（どんな枠にしたい?）', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[desired_streaming_style]',
                           @survey_profile.survey_response&.desired_streaming_style,
@@ -194,7 +194,7 @@
       </div>
 
       <!-- 理想の視聴者層 -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[desired_listener]', '理想の視聴者層（どんなリスナーに来てほしい?）', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[desired_listener]',
                           @survey_profile.survey_response&.desired_listener,
@@ -226,21 +226,29 @@
         <%= label_tag 'survey_result[goal_source]', '成長の星(目標)の出典選択', class: 'block mb-2 font-bold text-gray-700' %>
         <div class="space-y-2">
           <% 
-            # バリデーションエラー時に選択されていた値を保持
-            # enum の値は文字列として比較する必要がある
-            selected_goal_source = @survey_profile.survey_result&.goal_source
+            # バリデーションエラー時は params から、通常時は @survey_profile.survey_result から取得
+            if params.dig(:survey_result, :goal_source).present?
+              # バリデーションエラー時: params から取得 (文字列の '0' や '1')
+              selected_goal_source = params[:survey_result][:goal_source].to_i
+            elsif @survey_profile.survey_result&.goal_source.present?
+              # 通常時: enum の値を整数に変換
+              selected_goal_source = @survey_profile.survey_result.goal_source == 'ai_suggestion' ? 0 : 1
+            else
+              # デフォルト値
+              selected_goal_source = 0
+            end
           %>
           <label class="flex items-center">
             <%= radio_button_tag 'survey_result[goal_source]', 
                                  0, 
-                                 selected_goal_source == 'ai_suggestion' || selected_goal_source.nil?, 
+                                 selected_goal_source == 0, 
                                  class: 'mr-2' %>
             AI提案から選択する
           </label>
           <label class="flex items-center">
             <%= radio_button_tag 'survey_result[goal_source]', 
                                  1, 
-                                 selected_goal_source == 'self_set', 
+                                 selected_goal_source == 1, 
                                  class: 'mr-2' %>
             自分で設定する
           </label>
@@ -254,13 +262,13 @@
         <%= text_field_tag 'survey_result[goal_title]',
                    @survey_profile.survey_result&.goal_title,
                    class: 'border border-gray-300 rounded px-3 py-2',
-                   style: 'width: 100%; max-width: 500px;',
+                   style: 'width: 100%; max-width: 450px;',
                    placeholder: '例: 3ヶ月で平均視聴者数20人を目指す!' %>
         <p class="text-sm text-gray-500 mt-1">自分で設定する場合は入力してください</p>
       </div>
 
       <!-- 目標の詳細説明 -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_result[goal_description]', '成長の星（目標）の詳細説明', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_result[goal_description]',
                           @survey_profile.survey_result&.goal_description,

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -55,7 +55,7 @@
           <!-- フッター（AI提案バッジ） -->
           <div class="mt-4">
             <span class="badge rounded-pill px-3 py-2" style="background-color: #ddd6fe; color: #7c3aed; font-size: 0.875rem;">
-              <%= @goal.survey_result.goal_source == 0 ? '🤖 AI提案' : '✍️ 自分で設定' %>
+              <%= @goal.survey_result.ai_suggestion? ? '🤖 AI提案' : '✍️ 自分で設定' %>
             </span>
           </div>
         </div>
@@ -268,7 +268,10 @@
           <div class="p-3 rounded" style="background-color: #f9fafb;">
             <p class="small text-muted mb-2">💰 理想の月収</p>
             <p class="h4 fw-bold text-dark mb-0">
-              <%= number_to_currency(@goal.survey_profile.survey_response.desired_monthly_income, unit: '¥', precision: 0) %>
+              <%= number_to_currency(@goal.survey_profile.survey_response.desired_monthly_income, 
+                         unit: '円', 
+                         format: '%n%u',
+                         precision: 0) %>
             </p>
           </div>
         </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -6,6 +6,8 @@
           <h3 class="card-title text-center mb-4"><%= t('profiles.edit.title') %></h3>
 
           <%= form_with model: @user, url: profile_path, local: true, html: { multipart: true } do |f| %>
+
+            <%= render 'shared/error_messages', object: f.object %>
             
             <!-- プロフィール画像 -->
             <div class="mb-4 text-center">

--- a/app/views/sparks/_spark.html.erb
+++ b/app/views/sparks/_spark.html.erb
@@ -21,9 +21,16 @@
                 <small class="text-muted">
                   <%= t('sparks.show.posted_at') %>: <%= l spark.created_at, format: :short %>
                   <% if spark.created_at != spark.updated_at %>
-                    （<%= t('sparks.show.last_updated') %>: <%= l spark.updated_at, format: :short %>）
+                    <span class="d-none d-sm-inline">
+                      （<%= t('sparks.show.last_updated') %>: <%= l spark.updated_at, format: :short %>）
+                    </span>
                   <% end %>
                 </small>
+                <% if spark.created_at != spark.updated_at %>
+                  <small class="text-muted d-block d-sm-none">
+                    <%= t('sparks.show.last_updated') %>: <%= l spark.updated_at, format: :short %>
+                  </small>
+                <% end %>
               </div>
               
               <!-- 編集・削除ボタン（自分の投稿のみ表示） -->

--- a/app/views/survey_profiles/edit.html.erb
+++ b/app/views/survey_profiles/edit.html.erb
@@ -119,7 +119,7 @@
       </div>
 
       <!-- 配信で嬉しかった瞬間 -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[happy_moment]', '配信をしていて嬉しかったこと', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[happy_moment]',
                           @survey_profile.survey_response&.happy_moment,
@@ -129,7 +129,7 @@
       </div>
 
       <!-- 配信で辛かった瞬間 -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[sad_moment]', '配信をしていて悲しかったこと（もやもやの原因）', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[sad_moment]',
                           @survey_profile.survey_response&.sad_moment,
@@ -174,7 +174,7 @@
       </div>
 
       <!-- 配信を続ける理由（その他） -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[streaming_reasons_other]', '配信を続ける理由や目的（その他）', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[streaming_reasons_other]',
                           @survey_profile.survey_response&.streaming_reasons_other,
@@ -184,7 +184,7 @@
       </div>
 
       <!-- 理想の配信スタイル -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[desired_streaming_style]', '理想の配信スタイル（どんな枠にしたい?）', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[desired_streaming_style]',
                           @survey_profile.survey_response&.desired_streaming_style,
@@ -194,7 +194,7 @@
       </div>
 
       <!-- 理想の視聴者層 -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[desired_listener]', '理想の視聴者層（どんなリスナーに来てほしい?）', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[desired_listener]',
                           @survey_profile.survey_response&.desired_listener,
@@ -226,21 +226,29 @@
         <%= label_tag 'survey_result[goal_source]', '成長の星(目標)の出典選択', class: 'block mb-2 font-bold text-gray-700' %>
         <div class="space-y-2">
           <% 
-            # バリデーションエラー時に選択されていた値を保持
-            # enum の値は文字列として比較する必要がある
-            selected_goal_source = @survey_profile.survey_result&.goal_source
+            # バリデーションエラー時は params から、通常時は @survey_profile.survey_result から取得
+            if params.dig(:survey_result, :goal_source).present?
+              # バリデーションエラー時: params から取得 (文字列の '0' や '1')
+              selected_goal_source = params[:survey_result][:goal_source].to_i
+            elsif @survey_profile.survey_result&.goal_source.present?
+              # 通常時: enum の値を整数に変換
+              selected_goal_source = @survey_profile.survey_result.goal_source == 'ai_suggestion' ? 0 : 1
+            else
+              # デフォルト値
+              selected_goal_source = 0
+            end
           %>
           <label class="flex items-center">
             <%= radio_button_tag 'survey_result[goal_source]', 
                                  0, 
-                                 selected_goal_source == 'ai_suggestion' || selected_goal_source.nil?, 
+                                 selected_goal_source == 0, 
                                  class: 'mr-2' %>
             AI提案から選択する
           </label>
           <label class="flex items-center">
             <%= radio_button_tag 'survey_result[goal_source]', 
                                  1, 
-                                 selected_goal_source == 'self_set', 
+                                 selected_goal_source == 1, 
                                  class: 'mr-2' %>
             自分で設定する
           </label>
@@ -254,12 +262,13 @@
         <%= text_field_tag 'survey_result[goal_title]',
                            @survey_profile.survey_result&.goal_title,
                            class: 'w-full border border-gray-300 rounded px-3 py-2',
+                           style: 'width: 100%; max-width: 450px;',
                            placeholder: '例: 3ヶ月で平均視聴者数20人を目指す!' %>
         <p class="text-sm text-gray-500 mt-1">自分で設定する場合は入力してください</p>
       </div>
 
       <!-- 目標の詳細説明 -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_result[goal_description]', '成長の星（目標）の詳細説明', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_result[goal_description]',
                           @survey_profile.survey_result&.goal_description,

--- a/app/views/survey_profiles/new.html.erb
+++ b/app/views/survey_profiles/new.html.erb
@@ -119,7 +119,7 @@
       </div>
 
       <!-- 配信で嬉しかった瞬間 -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[happy_moment]', '配信をしていて嬉しかったこと', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[happy_moment]',
                           @survey_profile.survey_response&.happy_moment,
@@ -129,7 +129,7 @@
       </div>
 
       <!-- 配信で辛かった瞬間 -->
-      <div class="mb-4">
+      <div class="mb-4 form-field ">
         <%= label_tag 'survey_profile[sad_moment]', '配信をしていて悲しかったこと（もやもやの原因）', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[sad_moment]',
                           @survey_profile.survey_response&.sad_moment,
@@ -174,7 +174,7 @@
       </div>
 
       <!-- 配信を続ける理由（その他） -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[streaming_reasons_other]', '配信を続ける理由や目的（その他）', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[streaming_reasons_other]',
                           @survey_profile.survey_response&.streaming_reasons_other,
@@ -184,7 +184,7 @@
       </div>
 
       <!-- 理想の配信スタイル -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[desired_streaming_style]', '理想の配信スタイル（どんな枠にしたい?）', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[desired_streaming_style]',
                           @survey_profile.survey_response&.desired_streaming_style,
@@ -194,7 +194,7 @@
       </div>
 
       <!-- 理想の視聴者層 -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_profile[desired_listener]', '理想の視聴者層（どんなリスナーに来てほしい?）', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_profile[desired_listener]',
                           @survey_profile.survey_response&.desired_listener,
@@ -226,21 +226,29 @@
         <%= label_tag 'survey_result[goal_source]', '成長の星(目標)の出典選択', class: 'block mb-2 font-bold text-gray-700' %>
         <div class="space-y-2">
           <% 
-            # バリデーションエラー時に選択されていた値を保持
-            # enum の値は文字列として比較する必要がある
-            selected_goal_source = @survey_profile.survey_result&.goal_source
+            # バリデーションエラー時は params から、通常時は @survey_profile.survey_result から取得
+            if params.dig(:survey_result, :goal_source).present?
+              # バリデーションエラー時: params から取得 (文字列の '0' や '1')
+              selected_goal_source = params[:survey_result][:goal_source].to_i
+            elsif @survey_profile.survey_result&.goal_source.present?
+              # 通常時: enum の値を整数に変換
+              selected_goal_source = @survey_profile.survey_result.goal_source == 'ai_suggestion' ? 0 : 1
+            else
+              # デフォルト値
+              selected_goal_source = 0
+            end
           %>
           <label class="flex items-center">
             <%= radio_button_tag 'survey_result[goal_source]', 
                                  0, 
-                                 selected_goal_source == 'ai_suggestion' || selected_goal_source.nil?, 
+                                 selected_goal_source == 0, 
                                  class: 'mr-2' %>
             AI提案から選択する
           </label>
           <label class="flex items-center">
             <%= radio_button_tag 'survey_result[goal_source]', 
                                  1, 
-                                 selected_goal_source == 'self_set', 
+                                 selected_goal_source == 1, 
                                  class: 'mr-2' %>
             自分で設定する
           </label>
@@ -254,13 +262,13 @@
         <%= text_field_tag 'survey_result[goal_title]',
                    @survey_profile.survey_result&.goal_title,
                    class: 'border border-gray-300 rounded px-3 py-2',
-                   style: 'width: 100%; max-width: 500px;',
+                   style: 'width: 100%; max-width: 450px;',
                    placeholder: '例: 3ヶ月で平均視聴者数20人を目指す!' %>
         <p class="text-sm text-gray-500 mt-1">自分で設定する場合は入力してください</p>
       </div>
 
       <!-- 目標の詳細説明 -->
-      <div class="mb-4">
+      <div class="mb-4 form-field">
         <%= label_tag 'survey_result[goal_description]', '成長の星（目標）の詳細説明', class: 'block mb-2 font-bold text-gray-700' %>
         <%= text_area_tag 'survey_result[goal_description]',
                           @survey_profile.survey_result&.goal_description,

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -51,6 +51,9 @@ ja:
         motivation_level: "モチベーションレベル"
         listener_dropout_rate: "最近のリスナー離脱人数"
 
+      survey_response:
+        streaming_reasons: "配信を続ける理由や目的"
+
   errors:
     template:
       body: "次の項目を確認してください"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,12 @@ ja:
       description_html: |
         配信でのもやもやな結晶(想い)を調べて、<br>
         成長の星⭐(目標)に大変身 星を空に描いて、輝く大星座 君だけの銀河を創り上げよう✨
+    contact:
+      title: 'お問い合わせ'
+    privacy:
+      title: 'プライバシーポリシー'
+    terms:
+      title: '利用規約'
 
   user_sessions:
     new:
@@ -138,11 +144,3 @@ ja:
     update:
       success: 'プロフィールを更新しました'
       failure: 'プロフィールの更新に失敗しました'
-
-  static_pages:
-    contact:
-      title: 'お問い合わせ'
-    privacy:
-      title: 'プライバシーポリシー'
-    terms:
-      title: '利用規約'


### PR DESCRIPTION
## 概要
MVPレビュー前の細かい修正を行いました。

## 変更内容
- トップ画面の翻訳ミス修正
- もやもや結晶シート調査のフォームの長さ統一・レスポンシブ対応
- もやもや結晶シート調査の理由選択3つまでバリデーション追加
- 成長の星の出典選択のバリデーションエラー時のデータ保持
- スパークコントローラーにアラート・デバッグログ追加
- プロフィール編集画面にバリデーションエラー表示追加

## テスト結果
- Rspec: 全てパス
- Rubocop: エラー0

## 確認事項
- [x] 各画面の動作確認
- [x] バリデーションエラーの表示確認
- [x] レスポンシブ対応の確認