### PR TITLE
AI提案機能の3回制限を実装

### DIFF
--- a/app/controllers/survey_profiles_controller.rb
+++ b/app/controllers/survey_profiles_controller.rb
@@ -41,7 +41,7 @@ class SurveyProfilesController < ApplicationController
     suggestion = fetch_suggestion_from_gemini(survey_profile, survey_response)
 
     # カウントを増やす
-    current_user.increment!(:ai_suggestion_count)
+    current_user.update!(ai_suggestion_count: current_user.ai_suggestion_count + 1)
 
     # JSONで返す
     render json: suggestion
@@ -310,10 +310,26 @@ class SurveyProfilesController < ApplicationController
 
   # AI提案の利用回数制限をチェック
   def check_ai_suggestion_limit
-    if current_user.ai_suggestion_count >= 3
-      render json: {
-        error: 'AI提案の利用回数が上限（3回）に達しました。自分で設定する方法で目標を作成してください。'
-      }, status: :forbidden
-    end
+    # 日付が変わっていたらカウントをリセット
+    reset_ai_suggestion_count_if_needed
+
+    return unless current_user.ai_suggestion_count >= 3
+
+    render json: {
+      error: 'AI提案の利用回数が上限（3回）に達しました。自分で設定する方法で目標を作成してください。'
+    }, status: :forbidden
+  end
+
+  #  カウントをリセット
+  def reset_ai_suggestion_count_if_needed
+    today = Date.current
+
+    # 最後にリセットした日付が今日でない場合、リセット
+    return unless current_user.ai_suggestion_reset_date != today
+
+    current_user.update!(
+      ai_suggestion_count: 0,
+      ai_suggestion_reset_date: today
+    )
   end
 end

--- a/app/controllers/survey_profiles_controller.rb
+++ b/app/controllers/survey_profiles_controller.rb
@@ -2,6 +2,7 @@
 
 class SurveyProfilesController < ApplicationController
   before_action :require_login
+  before_action :check_ai_suggestion_limit, only: [:fetch_ai_suggestion]
 
   def new
     @survey_profile = SurveyProfile.new
@@ -38,6 +39,9 @@ class SurveyProfilesController < ApplicationController
 
     # AI提案を取得
     suggestion = fetch_suggestion_from_gemini(survey_profile, survey_response)
+
+    # カウントを増やす
+    current_user.increment!(:ai_suggestion_count)
 
     # JSONで返す
     render json: suggestion
@@ -302,5 +306,14 @@ class SurveyProfilesController < ApplicationController
   def handle_gemini_error(error)
     Rails.logger.error "AI提案の取得に失敗しました: #{error.message}"
     render json: { error: 'AI提案の取得に失敗しました' }, status: :internal_server_error
+  end
+
+  # AI提案の利用回数制限をチェック
+  def check_ai_suggestion_limit
+    if current_user.ai_suggestion_count >= 3
+      render json: {
+        error: 'AI提案の利用回数が上限（3回）に達しました。自分で設定する方法で目標を作成してください。'
+      }, status: :forbidden
+    end
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -127,6 +127,21 @@ function initializeForm() {
         body: JSON.stringify(formData)
       });
 
+      // ★★★ 利用回数制限に達した場合 ★★★
+      if (response.status === 403) {
+        const errorData = await response.json();
+
+        // フォームをクリア
+        if (goalTitleField) goalTitleField.value = '';
+        if (goalDescriptionField) goalDescriptionField.value = '';
+        if (actionPlanField) actionPlanField.value = '';
+
+        // エラーメッセージを表示
+        alert(errorData.error || 'AI提案の利用回数が上限に達しました。');
+        return; // ここで終了
+      }
+
+
       if (!response.ok) {
         throw new Error('AI提案の取得に失敗しました');
       }

--- a/db/migrate/20260422013115_add_ai_suggestion_count_to_users.rb
+++ b/db/migrate/20260422013115_add_ai_suggestion_count_to_users.rb
@@ -1,0 +1,5 @@
+class AddAiSuggestionCountToUsers < ActiveRecord::Migration[7.0]
+  def change
+     add_column :users, :ai_suggestion_count, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20260422051352_add_ai_suggestion_reset_date_to_users.rb
+++ b/db/migrate/20260422051352_add_ai_suggestion_reset_date_to_users.rb
@@ -1,0 +1,5 @@
+class AddAiSuggestionResetDateToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :ai_suggestion_reset_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_12_010210) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_22_013115) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -107,6 +107,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_12_010210) do
     t.string "avatar"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "ai_suggestion_count", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_22_013115) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_22_051352) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -108,6 +108,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_22_013115) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "ai_suggestion_count", default: 0, null: false
+    t.date "ai_suggestion_reset_date"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/requests/survey_profiles_spec.rb
+++ b/spec/requests/survey_profiles_spec.rb
@@ -52,6 +52,50 @@ RSpec.describe 'SurveyProfiles', type: :request do
         expect(json['goal_description']).to eq('# テスト説明')
         expect(json['action_plan']).to eq('# テスト計画')
       end
+
+      # AI提案を3回まで利用できること
+      it 'AI提案を3回まで利用できること' do
+        3.times do
+          post fetch_ai_suggestion_survey_profiles_path, params: valid_params
+
+          expect(response).to have_http_status(:success)
+          json = response.parsed_body
+          expect(json['goal_title']).to eq('テスト目標')
+          expect(json['goal_description']).to eq('# テスト説明')
+          expect(json['action_plan']).to eq('# テスト計画')
+        end
+
+        # カウントが3になっていることを確認
+        user.reload
+        expect(user.ai_suggestion_count).to eq(3)
+      end
+
+      # 日付が変わった後、カウントがリセットされること
+      it '日付が変わった後、カウントがリセットされること' do
+        # 3回AI提案を利用
+        3.times do
+          post fetch_ai_suggestion_survey_profiles_path, params: valid_params
+        end
+
+        # カウントが3になっていることを確認
+        user.reload
+        expect(user.ai_suggestion_count).to eq(3)
+
+        # 日付を昨日に変更
+        user.update!(ai_suggestion_reset_date: Date.yesterday)
+
+        # 再度AI提案を利用
+        post fetch_ai_suggestion_survey_profiles_path, params: valid_params
+
+        expect(response).to have_http_status(:success)
+        json = response.parsed_body
+        expect(json['goal_title']).to eq('テスト目標')
+
+        # カウントがリセットされ、1にカウントされていることを確認
+        user.reload
+        expect(user.ai_suggestion_count).to eq(1)
+        expect(user.ai_suggestion_reset_date).to eq(Date.current)
+      end
     end
 
     context '異常系' do
@@ -111,6 +155,30 @@ RSpec.describe 'SurveyProfiles', type: :request do
           expect(response).to have_http_status(:internal_server_error)
           json = response.parsed_body
           expect(json['error']).to eq('AI提案の取得に失敗しました')
+        end
+      end
+
+      # 3回制限に達した後、403 Forbidden が返されること
+      context '3回制限に達した場合' do
+        before do
+          # ユーザーのカウントを3に設定
+          user.update!(ai_suggestion_count: 3, ai_suggestion_reset_date: Date.current)
+
+          allow_any_instance_of(GeminiService).to receive(:suggest_streamer_goal).and_return(
+            {
+              goal_title: 'テスト目標',
+              goal_description: '# テスト説明',
+              action_plan: '# テスト計画'
+            }
+          )
+        end
+
+        it '403 Forbidden が返されること' do
+          post fetch_ai_suggestion_survey_profiles_path, params: valid_params
+
+          expect(response).to have_http_status(:forbidden)
+          json = response.parsed_body
+          expect(json['error']).to eq('AI提案の利用回数が上限（3回）に達しました。自分で設定する方法で目標を作成してください。')
         end
       end
     end

--- a/spec/system/survey_profiles_spec.rb
+++ b/spec/system/survey_profiles_spec.rb
@@ -351,6 +351,61 @@ RSpec.describe 'SurveyProfiles', type: :system do
           expect(page).to have_content('週あたりの配信回数を入力してください'), 'バリデーションエラーが表示されません'
         end
       end
+
+      context '3回制限に達した場合' do
+        before do
+          # ユーザーのカウントを3に設定
+          user.update!(ai_suggestion_count: 3, ai_suggestion_reset_date: Date.current)
+
+          # どのインスタンスに対してもスタブが効くようにする
+          allow_any_instance_of(GeminiService).to receive(:suggest_streamer_goal).and_return(
+            {
+              goal_title: 'テスト目標',
+              goal_description: 'テスト説明',
+              action_plan: 'テスト計画'
+            }
+          )
+        end
+
+        it '3回制限に達した後、エラーメッセージが表示されること', js: true do
+          # アンケートページに遷移
+          visit new_survey_profile_path
+
+          # ページが表示されるまで待機
+          expect(page).to have_content('もやもや結晶シート'), 'アンケートページが表示されません'
+
+          # フォーム入力
+          select 'YouTube', from: '配信プラットフォーム'
+          select 'ゲーム実況', from: '配信ジャンル'
+          select '初心者(1ヶ月未満)', from: '配信経験'
+          fill_in 'survey_profile_weekly_frequency', with: 3
+          fill_in 'survey_profile_average_listeners', with: 10
+          fill_in 'survey_profile_total_listeners', with: 100
+          select '1〜2人', from: '最近のリスナーの離脱人数'
+          choose 'survey_profile_motivation_level_3'
+          fill_in 'survey_profile_happy_moment', with: 'リスナーさんからコメントをもらえたとき'
+          fill_in 'survey_profile_sad_moment', with: 'リスナーが全然増えない'
+          check '稼ぎたい'
+          check '有名になりたい'
+          check '友達を作りたい'
+          fill_in 'survey_profile_streaming_reasons_other', with: '特になし'
+          fill_in 'survey_profile_desired_streaming_style', with: 'みんなでワイワイ楽しめる配信'
+          fill_in 'survey_profile_desired_listener', with: '優しくて楽しい人'
+          fill_in 'survey_profile_desired_monthly_income', with: 50_000
+
+          # alert() が表示されることを確認
+          alert_message = accept_alert do
+            # AI提案から選択するラジオボタンを選択
+            choose 'goal_source_ai'
+
+            # アラートが表示されるまで待機
+            sleep 3
+          end
+
+          # アラートのメッセージを検証
+          expect(alert_message).to eq('AI提案の利用回数が上限（3回）に達しました。自分で設定する方法で目標を作成してください。'), 'エラーメッセージが表示されません'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
AI提案機能に1日3回までの利用制限を実装しました。

## 変更内容
- User モデルに `ai_suggestion_count` と `ai_suggestion_reset_date` カラムを追加
- SurveyProfilesController に3回制限のロジックを実装
- 日付が変わったらカウントをリセットする機能を実装
- テストコードを追加

## テスト
- spec/requests/survey_profiles_spec.rb
  - AI提案を3回まで利用できること
  - 日付が変わった後、カウントがリセットされること
  - 3回制限に達した後、403 Forbidden が返されること

- spec/system/survey_profiles_spec.rb
  - 3回制限に達した後、エラーメッセージが表示されること

## 確認事項
- [x] テストが全て通ること
- [x] Rubocop が通ること
- [x] 実際にブラウザで動作確認を行ったこと