### PR TITLE
feat: AI機能のタイムアウト設定とエラーハンドリングの強化

### DIFF
--- a/app/controllers/concerns/ai_error_handler.rb
+++ b/app/controllers/concerns/ai_error_handler.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module AiErrorHandler
+  extend ActiveSupport::Concern
+
+  private
+
+  # レート制限エラーのハンドリング
+  def handle_rate_limit_error(error)
+    Rails.logger.error "AI suggestion rate limit exceeded: #{error.message}"
+    render json: {
+      error: t('survey_profiles.errors.rate_limit_exceeded')
+    }, status: :too_many_requests
+  end
+
+  # 不正なレスポンスエラーのハンドリング
+  def handle_invalid_response_error(error)
+    Rails.logger.error "AI suggestion invalid response: #{error.message}"
+    render json: {
+      error: t('survey_profiles.errors.invalid_response')
+    }, status: :internal_server_error
+  end
+
+  # Gemini API エラーのハンドリング
+  def handle_gemini_error(error)
+    Rails.logger.error "AI suggestion fetch failed: #{error.message}"
+    render json: { error: t('survey_profiles.errors.ai_suggestion_fetch_failed') }, status: :internal_server_error
+  end
+end

--- a/app/controllers/survey_profiles_controller.rb
+++ b/app/controllers/survey_profiles_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SurveyProfilesController < ApplicationController
+  include AiErrorHandler
+
   before_action :require_login
   before_action :check_ai_suggestion_limit, only: [:fetch_ai_suggestion]
 
@@ -45,6 +47,10 @@ class SurveyProfilesController < ApplicationController
 
     # JSONで返す
     render json: suggestion
+  rescue GeminiService::RateLimitError => e
+    handle_rate_limit_error(e)
+  rescue GeminiService::InvalidResponseError => e
+    handle_invalid_response_error(e)
   rescue GeminiService::ApiError => e
     handle_gemini_error(e)
   end
@@ -300,12 +306,6 @@ class SurveyProfilesController < ApplicationController
       survey_profile: survey_profile,
       survey_response: survey_response
     )
-  end
-
-  # Gemini API エラーのハンドリング
-  def handle_gemini_error(error)
-    Rails.logger.error "AI suggestion fetch failed: #{error.message}"
-    render json: { error: t('survey_profiles.errors.ai_suggestion_fetch_failed') }, status: :internal_server_error
   end
 
   # AI提案の利用回数制限をチェック

--- a/app/services/gemini_service.rb
+++ b/app/services/gemini_service.rb
@@ -18,7 +18,16 @@ class GeminiService
         service: 'generative-language-api',
         api_key: ENV.fetch('GEMINI_API_KEY')
       },
-      options: { model: 'gemini-2.5-flash', server_sent_events: true }
+      options: {
+        model: 'gemini-2.5-flash',
+        server_sent_events: true,
+        connection: {
+          request: {
+            timeout: 30,        # 読み込みタイムアウト（30秒）
+            open_timeout: 10    # 接続タイムアウト（10秒）
+          }
+        }
+      }
     )
   rescue KeyError => e
     Rails.logger.error "Gemini API key not found: #{e.message}"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -119,6 +119,8 @@ ja:
     # AI機能の翻訳を追加 
     errors:
       ai_suggestion_fetch_failed: 'AI提案の取得に失敗しました'
+      rate_limit_exceeded: "APIの利用制限に達しました。しばらくしてから再度お試しください。"
+      invalid_response: "AIからの応答が不正です。しばらくしてから再度お試しください。"
       ai_suggestion_limit_reached: 'AI提案の利用回数が上限（3回）に達しました。自分で設定する方法で目標を作成してください。'
 
     


### PR DESCRIPTION
## 概要
AI機能（Gemini API）のタイムアウト設定とエラーハンドリングを強化しました。

## 変更内容

### 1. タイムアウト設定の追加
- `GeminiService` の `initialize` メソッドで、 `timeout` と `open_timeout` を設定
  - `timeout: 30` : APIからのレスポンス待ち時間を30秒に設定
  - `open_timeout: 10` : API接続の待ち時間を10秒に設定

### 2. エラーの種類別メッセージ出し分け
- **レート制限エラー** (`RateLimitError`) : APIの利用制限に達した場合
- **不正なレスポンスエラー** (`InvalidResponseError`) : AIからの応答が不正な場合
- **その他のAPIエラー** (`ApiError`) : その他のAPIエラーが発生した場合

### 3. エラーハンドリングのConcern化
- `AiErrorHandler` Concern を作成し、エラーハンドリングのロジックを1箇所にまとめました
- `SurveyProfilesController` で `include AiErrorHandler` により読み込み

### 4. 翻訳キーの追加
- エラーメッセージの翻訳キーを `config/locales/ja.yml` に追加
  - `rate_limit_exceeded` : レート制限エラーのメッセージ
  - `invalid_response` : 不正なレスポンスエラーのメッセージ

## 変更したファイル

- `app/services/gemini_service.rb` : タイムアウト設定を追加
- `app/controllers/concerns/ai_error_handler.rb` : エラーハンドリングのConcernを作成
- `app/controllers/survey_profiles_controller.rb` : Concernを読み込み
- `config/locales/ja.yml` : エラーメッセージの翻訳キーを追加

## テスト結果

### RuboCop

64 files inspected, no offenses detected


### RSpec

78 examples, 0 failures


### ブラウザでの動作確認

- AI提案の取得が正常に動作することを確認

## 備考

- エラーハンドリングを Concern に切り出すことで、コードの可読性と保守性が向上しました
- 他のコントローラーでも同じエラーハンドリングを再利用できるようになりました