### PR TITLE
fix: 本番環境でのGoogle OAuthコールバックURL設定を修正

### DIFF
--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -83,7 +83,12 @@ Rails.application.config.sorcery.configure do |config|
 
   config.google.key = ENV['GOOGLE_CLIENT_ID']
   config.google.secret = ENV['GOOGLE_CLIENT_SECRET']
-  config.google.callback_url = "http://localhost:3000/oauth/callback?provider=google"
+  # コールバック URL を環境に応じて設定
+  config.google.callback_url = if Rails.env.production?
+                                  "https://#{ENV['PRODUCTION_HOST']}/oauth/callback?provider=google"
+                                else
+                                  "http://0.0.0.0:3000/oauth/callback?provider=google"
+                                end
   config.google.user_info_mapping = {
     email: 'email',
     nickname: 'name' 


### PR DESCRIPTION
## 🎯 変更内容

### **問題:**

- 本番環境で Google OAuth ログイン後に `http://localhost:3000/` にリダイレクトされる

### **原因:**

- `config/initializers/sorcery.rb` で本番環境のコールバック URL が固定値（開発環境用）になっていた

### **修正内容:**

- 環境に応じてコールバック URL を動的に設定するように修正
- 本番環境では `https://#{ENV['PRODUCTION_HOST']}/oauth/callback?provider=google` を使用
- 開発環境では `http://0.0.0.0:3000/oauth/callback?provider=google` を使用

### **修正ファイル:**

- `config/initializers/sorcery.rb`

### **動作確認:**

- [ ] 開発環境で Google OAuth ログインが正常に動作する
- [ ] 本番環境で Google OAuth ログイン後に `https://oshi-sta.com/` にリダイレクトされる

---

## 📝 補足事項

### **本番環境での追加設定:**

本番環境では `.env.production` に以下の環境変数を追加する必要があります:

```bash
PRODUCTION_HOST=oshi-sta.com