### PR TITLE
Add: ページネーション機能と円グラフのテストコードを追加

### DIFF
--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -200,5 +200,101 @@ RSpec.describe 'Dashboard', type: :system do
         expect(chart_data).to include(three_months_ago), "#{three_months_ago}のデータが表示されていません"
       end
     end
+
+    context '目標別の輝きメモ件数グラフ(円グラフ)' do
+      let!(:survey_profile1) { create(:survey_profile, user: user) }
+      let!(:survey_profile2) { create(:survey_profile, user: user) }
+      let!(:survey_profile3) { create(:survey_profile, user: user) }
+
+      before do
+        survey_profile1.survey_result.update!(goal_title: 'テスト目標1', goal_description: 'テスト説明1')
+        survey_profile2.survey_result.update!(goal_title: 'テスト目標2', goal_description: 'テスト説明2')
+        survey_profile3.survey_result.update!(goal_title: 'テスト目標3', goal_description: 'テスト説明3')
+      end
+
+      let!(:goal1) { create(:goal, user: user, survey_profile: survey_profile1) }
+      let!(:goal2) { create(:goal, user: user, survey_profile: survey_profile2) }
+      let!(:goal3) { create(:goal, user: user, survey_profile: survey_profile3) }
+
+      before do
+        # goal1に輝きメモを5件作成
+        create_list(:spark, 5, goal: goal1, user: user)
+
+        # goal2に輝きメモを10件作成
+        create_list(:spark, 10, goal: goal2, user: user)
+
+        # goal3に輝きメモを3件作成
+        create_list(:spark, 3, goal: goal3, user: user)
+      end
+
+      it 'ダッシュボードページに目標別の輝きメモ件数グラフ(円グラフ)が表示される', js: true do
+        # ダッシュボードにアクセス
+        visit dashboard_path
+
+        # ページの読み込みが完了するまで待つ
+        expect(page).to have_css('[data-controller="chart"]', wait: 10)
+
+        # 円グラフ(pie)の canvas 要素を取得
+        using_wait_time(10) do
+          expect(page).to have_selector('canvas[data-chart-type-value="pie"]'), '目標別の輝きメモ件数グラフ(円グラフ)が表示されていません'
+        end
+
+        # 円グラフの data-chart-data-value 属性の中身を検証
+        chart_element = page.find('canvas[data-chart-type-value="pie"]')
+        chart_data = chart_element['data-chart-data-value']
+
+        # 目標タイトルが含まれていることを確認
+        expect(chart_data).to include('テスト目標1'), 'テスト目標1のデータが表示されていません'
+        expect(chart_data).to include('テスト目標2'), 'テスト目標2のデータが表示されていません'
+        expect(chart_data).to include('テスト目標3'), 'テスト目標3のデータが表示されていません'
+      end
+
+      it '円グラフに正しいデータが含まれている', js: true do
+        # ダッシュボードにアクセス
+        visit dashboard_path
+
+        # ページの読み込みが完了するまで待つ
+        expect(page).to have_css('[data-controller="chart"]', wait: 10)
+
+        # 円グラフの canvas 要素を取得
+        using_wait_time(10) do
+          expect(page).to have_selector('canvas[data-chart-type-value="pie"]')
+        end
+
+        # 円グラフの data-chart-data-value 属性の中身を検証
+        chart_element = page.find('canvas[data-chart-type-value="pie"]')
+        chart_data = JSON.parse(chart_element['data-chart-data-value'])
+
+        # データセットの件数を確認
+        expect(chart_data['datasets'].first['data'].sum).to eq(18), '輝きメモの総件数が正しくありません'
+
+        # ラベルの数を確認
+        expect(chart_data['labels'].size).to eq(3), '目標の数が正しくありません'
+      end
+
+      context '輝きメモが存在しない場合' do
+        before do
+          # 前のテストで作成されたデータをすべて削除
+          Spark.destroy_all
+        end
+
+        let!(:survey_profile) { create(:survey_profile, user: user) }
+        let!(:goal) { create(:goal, user: user, survey_profile: survey_profile) }
+
+        before do
+          survey_profile.survey_result.update!(goal_title: 'テスト目標', goal_description: 'テスト説明')
+        end
+
+        it '「データがありません」と表示される' do
+          visit dashboard_path
+
+          # グラフのタイトルが表示されることを確認
+          expect(page).to have_content('各成長の星の輝き割合')
+
+          # 「データがありません」メッセージが表示されることを確認
+          expect(page).to have_content('データがありません')
+        end
+      end
+    end
   end
 end

--- a/spec/system/goals_spec.rb
+++ b/spec/system/goals_spec.rb
@@ -314,4 +314,143 @@ RSpec.describe 'Goals', type: :system do
       end
     end
   end
+
+  # ========================================
+  # 【追加】 ページネーションのテスト
+  # ========================================
+
+  describe '一覧ページのページネーション' do
+    context 'ページネーションが機能する場合' do
+      before do
+        # 10件の目標を作成(1ページ4件の場合)
+        10.times do |i|
+          profile = create(:survey_profile, user: user)
+          profile.survey_result.update!(
+            goal_title: "目標#{i + 1}",
+            goal_description: "説明#{i + 1}"
+          )
+          create(:goal, user: user, survey_profile: profile)
+        end
+
+        visit goals_path
+      end
+
+      it '1ページ目に4件の目標が表示される' do
+        # ビューファイルから .col-sm-12 .col-lg-6 のカードを数える
+        expect(page).to have_css('.col-sm-12', count: 4)
+      end
+
+      it '2ページ目に移動できる' do
+        click_link '2'
+        expect(page).to have_current_path(goals_path(page: 2))
+      end
+
+      it '2ページ目に4件の目標が表示される' do
+        click_link '2'
+        expect(page).to have_css('.col-sm-12', count: 4)
+      end
+
+      it '3ページ目に2件の目標が表示される' do
+        click_link '3'
+        expect(page).to have_css('.col-sm-12', count: 2)
+      end
+
+      it 'ページネーションのリンクが正しく表示される' do
+        expect(page).to have_css('.pagination')
+        expect(page).to have_link('2')
+        expect(page).to have_link('3')
+      end
+
+      it '目標のタイトルが表示される' do
+        expect(page).to have_content('目標10')
+        expect(page).to have_content('目標9')
+        expect(page).to have_content('目標8')
+        expect(page).to have_content('目標7')
+      end
+    end
+
+    context 'ページネーションが不要な場合' do
+      before do
+        # 3件の目標を作成
+        3.times do |i|
+          profile = create(:survey_profile, user: user)
+          profile.survey_result.update!(
+            goal_title: "目標#{i + 1}",
+            goal_description: "説明#{i + 1}"
+          )
+          create(:goal, user: user, survey_profile: profile)
+        end
+
+        visit goals_path
+      end
+
+      it 'ページネーションが表示されない' do
+        expect(page).not_to have_css('.pagination')
+      end
+
+      it '全ての目標が表示される' do
+        expect(page).to have_css('.col-sm-12', count: 3)
+      end
+
+      it '目標のタイトルが表示される' do
+        expect(page).to have_content('目標1')
+        expect(page).to have_content('目標2')
+        expect(page).to have_content('目標3')
+      end
+    end
+
+    context '検索機能とページネーションの組み合わせ' do
+      before do
+        # 10件の目標を作成
+        10.times do |i|
+          profile = create(:survey_profile, user: user)
+          profile.survey_result.update!(
+            goal_title: "目標#{i + 1}",
+            goal_description: "説明#{i + 1}"
+          )
+          create(:goal, user: user, survey_profile: profile)
+        end
+
+        # 検索キーワードに一致する目標を追加で作成
+        5.times do |i|
+          profile = create(:survey_profile, user: user)
+          profile.survey_result.update!(
+            goal_title: "特別な目標#{i + 1}",
+            goal_description: "特別な説明#{i + 1}"
+          )
+          create(:goal, user: user, survey_profile: profile)
+        end
+
+        visit goals_path
+      end
+
+      it '検索結果にページネーションが表示される' do
+        fill_in 'q', with: '特別な目標'
+        click_button '検索'
+
+        # 検索結果が表示されることを確認
+        expect(page).to have_content('「特別な目標」の検索結果')
+        expect(page).to have_css('.badge.bg-primary', text: '5件')
+
+        # 1ページ目に4件表示される
+        expect(page).to have_css('.col-sm-12', count: 4)
+
+        # 2ページ目に移動できる
+        expect(page).to have_link('2')
+      end
+
+      it '検索結果の2ページ目に移動できる' do
+        fill_in 'q', with: '特別な目標'
+        click_button '検索'
+
+        click_link '2'
+
+        # 2ページ目に1件表示される
+        expect(page).to have_css('.col-sm-12', count: 1)
+
+        # 検索キーワードが保持されている
+        expect(page).to have_field('q', with: '特別な目標')
+      end
+    end
+  end
 end

--- a/spec/system/sparks_spec.rb
+++ b/spec/system/sparks_spec.rb
@@ -181,4 +181,120 @@ RSpec.describe 'Sparks', type: :system do
       expect(page).not_to have_content('削除する内容'), '削除された内容が残っています'
     end
   end
+
+  # ========================================
+  # 【追加】 輝きのページネーションのテスト
+  # ========================================
+
+  describe '輝き一覧のページネーション' do
+    context 'ページネーションが機能する場合' do
+      before do
+        # 10件の輝きを作成（1ページ4件の場合、3ページ必要）
+        10.times do |i|
+          create(:spark, goal: goal, user: user, content: "輝き#{i + 1}")
+        end
+
+        visit goal_path(goal)
+      end
+
+      it '1ページ目に4件の輝きが表示される' do
+        # 輝きのカードを数える
+        expect(page).to have_css('.spark-item', count: 4)
+      end
+
+      it '2ページ目に移動できる' do
+        # 1ページ目に表示される輝きを確認
+        expect(page).to have_content('輝き10')
+        expect(page).to have_content('輝き9')
+
+        click_link '2'
+
+        # 2ページ目に表示される輝きを確認（1ページ目の輝きが消えていることを確認）
+        expect(page).not_to have_content('輝き10')
+        expect(page).not_to have_content('輝き9')
+
+        # 2ページ目の輝きが表示されることを確認
+        expect(page).to have_content('輝き6')
+        expect(page).to have_content('輝き5')
+      end
+
+      it '2ページ目に4件の輝きが表示される' do
+        click_link '2'
+        expect(page).to have_css('.spark-item', count: 4)
+      end
+
+      it '3ページ目に2件の輝きが表示される' do
+        click_link '3'
+        expect(page).to have_css('.spark-item', count: 2)
+      end
+
+      it 'ページネーションのリンクが正しく表示される' do
+        expect(page).to have_css('.pagination')
+        expect(page).to have_link('2')
+        expect(page).to have_link('3')
+      end
+
+      it '輝きの内容が表示される' do
+        # 降順表示の場合、最新の輝きが表示される
+        expect(page).to have_content('輝き10')
+        expect(page).to have_content('輝き9')
+        expect(page).to have_content('輝き8')
+        expect(page).to have_content('輝き7')
+      end
+    end
+
+    context 'ページネーションが不要な場合' do
+      before do
+        # 3件の輝きを作成
+        3.times do |i|
+          create(:spark, goal: goal, user: user, content: "輝き#{i + 1}")
+        end
+
+        visit goal_path(goal)
+      end
+
+      it 'ページネーションが表示されない' do
+        expect(page).not_to have_css('.pagination')
+      end
+
+      it '全ての輝きが表示される' do
+        expect(page).to have_css('.spark-item', count: 3)
+      end
+
+      it '輝きの内容が表示される' do
+        expect(page).to have_content('輝き3')
+        expect(page).to have_content('輝き2')
+        expect(page).to have_content('輝き1')
+      end
+    end
+
+    context '輝きを投稿した後のページネーション', js: true do
+      before do
+        # 4件の輝きを作成（1ページ目がちょうど埋まる）
+        4.times do |i|
+          create(:spark, goal: goal, user: user, content: "既存の輝き#{i + 1}")
+        end
+
+        visit goal_path(goal)
+      end
+
+      it '新しい輝きを投稿すると1ページ目に表示される' do
+        # 輝きを投稿
+        fill_in 'spark[content]', with: '新しい輝き'
+        click_button '輝きを記録'
+
+        # 投稿が成功するまで待機
+        expect(page).to have_content('輝きを記録しました'), 'フラッシュメッセージが表示されません'
+
+        # 1ページ目に新しい輝きが表示される
+        expect(page).to have_content('新しい輝き')
+
+        # 1ページ目に4件の輝きが表示される（新しい輝きが1番上に表示される）
+        expect(page).to have_css('.spark-item', count: 4)
+
+        # 2ページ目に移動できる
+        expect(page).to have_link('2')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
ページネーション機能と円グラフのテストコードを追加しました。

## 変更内容
### 1. 成長の星一覧ページのページネーション機能のテストコード追加
- **ファイル:** `spec/system/goals_spec.rb`
- **追加内容:**
  - 成長の星が11件以上ある場合、ページネーションが表示されることを確認するテスト
  - 2ページ目に遷移できることを確認するテスト

### 2. 輝きメモ一覧ページのページネーション機能のテストコード追加
- **ファイル:** `spec/system/sparks_spec.rb`
- **追加内容:**
  - 輝きメモが11件以上ある場合、ページネーションが表示されることを確認するテスト
  - 2ページ目に遷移できることを確認するテスト

### 3. ダッシュボードページの円グラフ表示のテストコード追加
- **ファイル:** `spec/system/dashboard_spec.rb`
- **追加内容:**
  - 目標別の輝きメモ件数グラフ(円グラフ)が表示されることを確認するテスト
  - 円グラフに正しいデータが含まれていることを確認するテスト
  - 輝きメモが存在しない場合、「データがありません」と表示されることを確認するテスト
  - 前のテストデータが残らないように、`destroy_all` でデータを削除する処理を追加

## テスト結果
### 全テスト実行結果
```bash
docker compose exec web bundle exec rspec
結果:

178 examples, 0 failures
個別テスト実行結果
docker compose exec web bundle exec rspec spec/system/dashboard_spec.rb
結果:

11 examples, 0 failures
RuboCop実行結果
docker compose exec web bundle exec rubocop
結果:

73 files inspected, no offenses detected